### PR TITLE
Decapitalize string in require.

### DIFF
--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -2,7 +2,7 @@ require 'redis'
 require 'net/http'
 require 'socket'
 require 'cgi'
-require 'Logger' unless defined?(Logger)
+require 'logger' unless defined?(Logger)
 
 module Wovnrb
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
 require 'pry'
-require 'Wovnrb'
+require 'wovnrb'

--- a/test/services/url_test.rb
+++ b/test/services/url_test.rb
@@ -1,4 +1,4 @@
-require 'wovnrb/services/URL'
+require 'wovnrb/services/url'
 
 class URLTest < Minitest::Test
 


### PR DESCRIPTION
Tests does not run on my Ubuntu. Mac OSX HFS is case-insensitive Filesystem by default.
https://blog.breadncup.com/2010/04/16/mac-osx-hfs-is-case-insensitive-filesystem-by-default/
