### PR TITLE
Fix for using as normal rack middleware.

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -14,6 +14,7 @@ module Wovnrb
   class Interceptor
     def initialize(app, opts={})
       @app = app
+      opts = opts.each_with_object({}){|(k,v),memo| memo[k.to_s]=v}
       STORE.settings.merge!(opts)
     end
 

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -12,8 +12,9 @@ module Wovnrb
   STORE = Store.new
 
   class Interceptor
-    def initialize(app)
+    def initialize(app, opts={})
       @app = app
+      Store.settings.merge!(opts)
     end
 
     def call(env)

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -14,7 +14,7 @@ module Wovnrb
   class Interceptor
     def initialize(app, opts={})
       @app = app
-      Store.settings.merge!(opts)
+      STORE.settings.merge!(opts)
     end
 
     def call(env)


### PR DESCRIPTION
This fix enables all rack based applications to use wovnrb, not only Rails.

```ruby
require 'sinatra'
require 'wovnrb'

use Wovnrb::Interceptor, {
  :user_token => 'IRb6-',
  'secret_key' => 'secret',
}

get '/' do
  '<html><body>Hello world!</body></html>'
end
```