### PR TITLE
Do not use "use_ssl" when http.scheme is "http".

### DIFF
--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -123,10 +123,10 @@ module Wovnrb
 
       begin
         uri = URI.parse("#{settings['api_url']}?token=#{settings['user_token']}&url=#{url}")
-        https = Net::HTTP.new(uri.host, uri.port)
-        https.use_ssl = true
-        res = https.start {
-          https.get(uri.request_uri)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true if uri.scheme == 'https'
+        res = http.start {
+          http.get(uri.request_uri)
         }
         if res.code == "200"
           vals = JSON.parse(res.body || '{}')


### PR DESCRIPTION
wovnrb gets no data when non https url is set to api_url property.