### PR TITLE
There is some case that the slash is needed.

### DIFF
--- a/lib/wovnrb/lang.rb
+++ b/lib/wovnrb/lang.rb
@@ -111,6 +111,7 @@ module Wovnrb
               new_href = '/' + @lang_code + href
             else
               current_dir = headers.pathname.sub(/[^\/]*\.[^\.]{2,6}$/, '')
+              current_dir = '/' if current_dir == ''
               new_href = '/' + @lang_code + current_dir + href
             end
         end

--- a/lib/wovnrb/lang.rb
+++ b/lib/wovnrb/lang.rb
@@ -56,6 +56,14 @@ module Wovnrb
       @lang_code
     end
 
+    # Adds language code to URL in "href" variable by "pattern" variable and own @lang_code.
+    #  When @lang_code is 'ja', add_lang_code('https://wovn.io', 'path', headers) returns 'https://wovn.io/ja/'.
+    # If you want to know more examples, see also test/lib/lang_test.rb.
+    #
+    # @param  [String] href            original URL.
+    # @param  [String] pattern         url_pattern of the settings. ('path', 'subdomain' or 'query')
+    # @param  [Wovnrb::Header] headers instance of Wovn::Header. It generates new env variable for original request.
+    # @return [String]                 URL added langauge code.
     def add_lang_code(href, pattern, headers)
       return href if href =~ /^(#.*)?$/
       # absolute links

--- a/test/lib/lang_test.rb
+++ b/test/lib/lang_test.rb
@@ -266,6 +266,12 @@ module Wovnrb
       assert_equal('/fr/hello/hey/index.html', lang.add_lang_code('hey/index.html', 'path', headers))
     end
 
+    def test_add_lang_code_relative_path_at_root
+      lang = Lang.new('fr')
+      headers = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://google.com/'), Wovnrb.get_settings)
+      assert_equal('/fr/index.html', lang.add_lang_code('index.html', 'path', headers))
+    end
+
     def generate_body(param = "")
       case param
         when "ignore_parent"


### PR DESCRIPTION
When accessing "http://wovn.io/ja", relative link like "policy" is replaced with "jacontact". This pull request fixes this.