### PR TITLE
Implement use_proxy option.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,10 @@
 /.bundle/
-<<<<<<< HEAD
 /vendor
-=======
-/vendor/bundle/
->>>>>>> 78ccf8410c19bdee508e96a2386a5273abfad0ba
-/.yardoc
+.yardoc/
 /Gemfile.lock
 /_yardoc/
 /coverage/
-/doc/
+doc/
 /pkg/
 /spec/reports/
 /tmp/

--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -10,6 +10,9 @@ module Wovnrb
     attr_reader :pathname
     attr_reader :redis_url
 
+    # Generates new instance of Wovnrb::Headers.
+    # Its parameters are set by parsing env variable.
+    #
     def initialize(env, settings)
       @env = env
       @settings = settings
@@ -68,6 +71,11 @@ module Wovnrb
       (self.path_lang && self.path_lang.length > 0) ? self.path_lang : @settings['default_lang']
     end
 
+    # picks up language code from requested URL by using url_pattern_reg setting.
+    # when language code is invalid, this method returns empty string.
+    # if you want examples, please see test/lib/headers_test.rb.
+    #
+    # @return [String] language code in requrested URL.
     def path_lang
       if @path_lang.nil?
         rp = Regexp.new(@settings['url_pattern_reg'])

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -14,6 +14,9 @@ module Wovnrb
       reset
     end
 
+    # Reset @settings and @config_loaded variables to default.
+    #
+    # @return [nil]
     def reset
       @settings =
         {

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -30,7 +30,8 @@ module Wovnrb
           'test_mode' => false,
           'test_url' => '',
           'cache_megabytes' => nil,
-          'ttl_seconds' => nil
+          'ttl_seconds' => nil,
+          'use_proxy' => false,  # use env['HTTP_X_FORWARDED_HOST'] instead of env['HTTP_HOST'] and env['SERVER_NAME'] when this setting is true.
         }
       # When Store is initialized, the Rails.configuration object is not yet initialized
       @config_loaded = false


### PR DESCRIPTION
When "use_proxy" option is true, wovnrb uses env['HTTP_X_FORWARDED_HOST'] instead of env['HTTP_HOST'] and env['SERVER_NAME'].

This function is for an application with reverse proxy.

Automatical using env['HTTP_X_FORWARDED_HOST'] has some security risk, so I have implemented this as an option.