### PR TITLE
"version" parameter is always empty in wovn script tag.

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -13,6 +13,7 @@ require 'wovnrb/html_replacers/meta_replacer'
 require 'wovnrb/html_replacers/image_replacer'
 require 'wovnrb/html_replacers/script_replacer'
 require 'wovnrb/railtie' if defined?(Rails)
+require 'wovnrb/version'
 
 module Wovnrb
   class Interceptor

--- a/lib/wovnrb/html_replacers/script_replacer.rb
+++ b/lib/wovnrb/html_replacers/script_replacer.rb
@@ -1,3 +1,5 @@
+require 'wovnrb/version'
+
 module Wovnrb
   class ScriptReplacer < ReplacerBase
     def initialize(store)

--- a/lib/wovnrb/html_replacers/script_replacer.rb
+++ b/lib/wovnrb/html_replacers/script_replacer.rb
@@ -1,5 +1,3 @@
-require 'wovnrb/version'
-
 module Wovnrb
   class ScriptReplacer < ReplacerBase
     def initialize(store)


### PR DESCRIPTION
Script tag of https://wovn.io is as follows. "version" parameter is always empty. We should do "require 'wovnrb/version'" in wovnrb.rb.

```html
<script src="//j.wovn.io/1" async="true" data-wovnio="key=2Wle3&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;version="> </script>
```

There are some tests about this. But "bundle exec rake test" command seems to load all modules, so the tests are working well.