### PR TITLE
Query parameter should be empty when query setting is not matching.

### DIFF
--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -55,6 +55,8 @@ module Wovnrb
         end
         if query_vals.length > 0
           @query = "?#{query_vals.sort.join('&')}"
+        else
+          @query = ''
         end
       else
         @query = ''

--- a/test/lib/headers_test.rb
+++ b/test/lib/headers_test.rb
@@ -82,7 +82,25 @@ class HeadersTest < Minitest::Test
    assert_equal('wovn.io', h.unmasked_host)
    assert_equal('localhost', env['HTTP_HOST'])
    assert_equal('localhost', env['SERVER_NAME'])
- end
+  end
+
+  def test_initialize_without_query
+    env = Wovnrb.get_env
+    h = Wovnrb::Headers.new(env, Wovnrb.get_settings)
+    assert_equal('wovn.io/dashboard', h.redis_url)
+  end
+
+  def test_initialize_with_query
+    env = Wovnrb.get_env
+    h = Wovnrb::Headers.new(env, Wovnrb.get_settings('query' => ['param']))
+    assert_equal('wovn.io/dashboard?param=val', h.redis_url)
+  end
+
+  def test_initialize_with_not_matching_query
+    env = Wovnrb.get_env
+    h = Wovnrb::Headers.new(env, Wovnrb.get_settings('query' => ['aaa']))
+    assert_equal('wovn.io/dashboard', h.redis_url)
+  end
 
   #########################
   # REQUEST_OUT


### PR DESCRIPTION
https://github.com/WOVNio/wovnjava/pull/39

In the following case, query should be empty string.

* query parameter: "p"
* page url: "localhost/?q=1"