### PR TITLE
Implement get_text method.

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -20,11 +20,11 @@ class Wovnrb
     @interceptor = Interceptor.instance || Interceptor.new(nil, opts)
   end
 
-  def get_text(srcs, domain, target_lang)
+  def get_text(srcs, host, target_lang)
 
     # Check paramters.
     if srcs.nil? || srcs.empty? || srcs.instance_of?(Array) == false
-        domain.nil? || domain.empty?
+        host.nil? || host.empty?
         target_lang.nil? || target_lang.empty?
       return nil
     end
@@ -35,9 +35,9 @@ class Wovnrb
       parsed_api_url = URI.parse(api_url)
       parsed_api_url.path = ''
 
-      uri = URI.join(parsed_api_url.to_s, '/v0/domain/values').to_s  \
+      uri = URI.join(parsed_api_url.to_s, '/v0/project/values').to_s  \
           + "?srcs=#{CGI::escape(srcs.to_json)}" \
-          + "&domain=#{CGI::escape(domain)}" \
+          + "&host=#{CGI::escape(host)}" \
           + "&target_lang=#{CGI::escape(target_lang)}" \
           + "&token=#{CGI::escape(@interceptor.store.settings['user_token'])}"
       parsed_uri = URI.parse(uri)

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -14,6 +14,7 @@ require 'wovnrb/html_replacers/image_replacer'
 require 'wovnrb/html_replacers/script_replacer'
 require 'wovnrb/railtie' if defined?(Rails)
 require 'wovnrb/version'
+require 'active_support/core_ext/object/blank'
 
 class Wovnrb
   def initialize(opts={})
@@ -23,22 +24,15 @@ class Wovnrb
   def get_text(srcs, host, target_lang)
 
     # Check paramters.
-    if srcs.nil? || srcs.empty? || srcs.instance_of?(Array) == false
-        host.nil? || host.empty?
-        target_lang.nil? || target_lang.empty?
-      return nil
+    if srcs.blank? || srcs.instance_of?(Array) == false || host.blank? || target_lang.blank?
+      raise ArgumentError, 'Invalid arguments'
     end
 
     # Send request to API server.
     api_data = ApiData.new(@interceptor.store)
-    begin
-      data = api_data.get_project_values(srcs, host, target_lang)
-    rescue => e
-      WovnLogger.instance.error("API server GET request failed :\n#{e.message}")
-      return nil
-    end
+    data = api_data.get_project_values(srcs, host, target_lang)
 
-    if data.nil? || data.has_key?('results') == false
+    if data.blank? || data.has_key?('results') == false
       return nil
     end
 

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -21,6 +21,12 @@ class Wovnrb
     @interceptor = Interceptor.instance || Interceptor.new(nil, opts)
   end
 
+  # Search texts.
+  #
+  # @param srcs [Array] search srcs
+  # @param host [String] search host
+  # @param target_lang [String] target lang
+  # @return [Array] dsts
   def get_text(srcs, host, target_lang)
 
     # Check paramters.

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -46,23 +46,13 @@ class Wovnrb
     end
 
     # Send request to API server.
-    http = Net::HTTP.new(parsed_uri.host, parsed_uri.port)
-    http.use_ssl = true if parsed_uri.scheme == 'https'
-    http.open_timeout = @interceptor.store.settings['api_timeout_seconds']
-    http.read_timeout = @interceptor.store.settings['api_timeout_seconds']
     begin
-      response = http.start {
-        http.get(parsed_uri.request_uri)
-      }
+      body = ApiData.get_from_api_server(parsed_uri)
     rescue => e
+      WovnLogger.instance.error("API server GET request failed :\nurl: #{parsed_uri}\n#{e.message}")
       return nil
     end
 
-    if response.code != '200'
-      return nil
-    end
-
-    body = response.body
     if body.nil? || body.empty?
       return nil
     end

--- a/lib/wovnrb/api_data.rb
+++ b/lib/wovnrb/api_data.rb
@@ -1,38 +1,36 @@
+require 'cgi'
+require 'json'
+require 'net/http'
+require 'uri'
+require 'wovnrb/text_caches/cache_base'
+require 'wovnrb/services/wovn_logger'
+
 class Wovnrb
   class ApiData
-    def initialize(access_url, store)
-      @access_url = access_url.gsub(/\/$/, '')
+    def initialize(store)
       @store = store
     end
 
-    def get_data
-      cache_key = to_key(@access_url)
-      data = get_data_value(cache_key)
+    def get_page_values(access_url)
+      @access_url = access_url
+      uri = build_page_values_uri
+      data = get_data_value(uri)
       JSON.parse(data)
     end
 
-    def get_from_api_server(uri)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true if uri.scheme == 'https'
-      http.open_timeout = @store.settings['api_timeout_seconds']
-      http.read_timeout= @store.settings['api_timeout_seconds']
-      response = http.start {
-        http.get(uri.request_uri)
-      }
-
-      if response.code == '200'
-        response.body
-      else
-        raise "Response Code is not success: #{response.code}"
-      end
+    def get_project_values(srcs, host, target_lang)
+      @srcs, @host, @target_lang = srcs, host, target_lang
+      uri = build_project_values_uri
+      data = get_data_value(uri)
+      JSON.parse(data)
     end
 
     private
-    def get_data_value(cache_key)
+    def get_data_value(uri)
+      cache_key = to_key(uri.query)
       cache_value = CacheBase.get_single.get(cache_key)
       return cache_value if cache_value
 
-      uri = build_api_uri
       begin
         response = get_from_api_server(uri)
       rescue => e
@@ -53,17 +51,48 @@ class Wovnrb
     # Generate api_url object for backend API.
     #
     # @return [URI::HTTP or URI::HTTPS] api_url object for backend API.
-    def build_api_uri
-      api_url = URI.parse(@store.settings['api_url'])
-      if md = api_url.path.match(/^\/v\d+/)
-        api_url.path = md[0] + '/values'  # use API version in api_url setting.
-      else
-        api_url.path = '/v0/values'
-      end
+    def build_page_values_uri
+      api_url = build_api_url('/values')
       t = CGI::escape(@store.settings['user_token'])
       u = CGI::escape(@access_url)
       api_url.query = "token=#{t}&url=#{u}"
       api_url
+    end
+
+    def build_project_values_uri
+      api_url = build_api_url('/project/values')
+      srcs = CGI::escape(@srcs.to_json)
+      host = CGI::escape(@host)
+      target_lang = CGI::escape(@target_lang)
+      token = CGI::escape(@store.settings['user_token'])
+      api_url.query = "srcs=#{srcs}&host=#{host}&target_lang=#{target_lang}&token=#{token}"
+      api_url
+    end
+
+    def build_api_url(path)
+      api_url = URI.parse(@store.settings['api_url'])
+      if md = api_url.path.match(/^\/v\d+/)
+        api_url.path = md[0] + path  # use API version in api_url setting.
+      else
+        api_url.path = '/v0' + path
+      end
+      api_url
+    end
+
+    def get_from_api_server(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true if uri.scheme == 'https'
+      http.open_timeout = @store.settings['api_timeout_seconds']
+      http.read_timeout= @store.settings['api_timeout_seconds']
+      response = http.start {
+        http.get(uri.request_uri)
+      }
+
+      if response.code == '200'
+        response.body
+      else
+        raise "Response Code is not success: #{response.code}"
+      end
     end
   end
 end

--- a/lib/wovnrb/api_data.rb
+++ b/lib/wovnrb/api_data.rb
@@ -11,6 +11,22 @@ class Wovnrb
       JSON.parse(data)
     end
 
+    def get_from_api_server(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true if uri.scheme == 'https'
+      http.open_timeout = @store.settings['api_timeout_seconds']
+      http.read_timeout= @store.settings['api_timeout_seconds']
+      response = http.start {
+        http.get(uri.request_uri)
+      }
+
+      if response.code == '200'
+        response.body
+      else
+        raise "Response Code is not success: #{response.code}"
+      end
+    end
+
     private
     def get_data_value(cache_key)
       cache_value = CacheBase.get_single.get(cache_key)
@@ -48,22 +64,6 @@ class Wovnrb
       u = CGI::escape(@access_url)
       api_url.query = "token=#{t}&url=#{u}"
       api_url
-    end
-
-    def get_from_api_server(uri)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true if uri.scheme == 'https'
-      http.open_timeout = @store.settings['api_timeout_seconds']
-      http.read_timeout= @store.settings['api_timeout_seconds']
-      response = http.start {
-        http.get(uri.request_uri)
-      }
-
-      if response.code == '200'
-        response.body
-      else
-        raise "Response Code is not success: #{response.code}"
-      end
     end
   end
 end

--- a/lib/wovnrb/api_data.rb
+++ b/lib/wovnrb/api_data.rb
@@ -34,10 +34,20 @@ class Wovnrb
       "#{@@cache_prefix}#{url}"
     end
 
+    # Generate api_url object for backend API.
+    #
+    # @return [URI::HTTP or URI::HTTPS] api_url object for backend API.
     def build_api_uri
+      api_url = URI.parse(@store.settings['api_url'])
+      if md = api_url.path.match(/^\/v\d+/)
+        api_url.path = md[0] + '/values'  # use API version in api_url setting.
+      else
+        api_url.path = '/v0/values'
+      end
       t = CGI::escape(@store.settings['user_token'])
       u = CGI::escape(@access_url)
-      URI.parse("#{@store.settings['api_url']}?token=#{t}&url=#{u}")
+      api_url.query = "token=#{t}&url=#{u}"
+      api_url
     end
 
     def get_from_api_server(uri)

--- a/lib/wovnrb/api_data.rb
+++ b/lib/wovnrb/api_data.rb
@@ -1,4 +1,4 @@
-module Wovnrb
+class Wovnrb
   class ApiData
     def initialize(access_url, store)
       @access_url = access_url.gsub(/\/$/, '')

--- a/lib/wovnrb/api_data.rb
+++ b/lib/wovnrb/api_data.rb
@@ -11,6 +11,10 @@ class Wovnrb
       @store = store
     end
 
+    # Get data from backend API.
+    #
+    # @param access_url [String] page URL
+    # @return [Hash] Data retrieved from API server
     def get_page_values(access_url)
       @access_url = access_url
       uri = build_page_values_uri
@@ -18,6 +22,12 @@ class Wovnrb
       JSON.parse(data)
     end
 
+    # Get data from Project Translation Text Search API.
+    #
+    # @param srcs [Array] search srcs
+    # @param host [String] search host
+    # @param target_lang [String] target language
+    # @return [Hash] Data retrieved from API server
     def get_project_values(srcs, host, target_lang)
       @srcs, @host, @target_lang = srcs, host, target_lang
       uri = build_project_values_uri
@@ -26,6 +36,11 @@ class Wovnrb
     end
 
     private
+
+    # Get data from API server.
+    #
+    # @param uri [URI] API server URI object
+    # @return [Hash] Data retrieved from API server
     def get_data_value(uri)
       cache_key = to_key(uri.query)
       cache_value = CacheBase.get_single.get(cache_key)
@@ -44,13 +59,17 @@ class Wovnrb
     end
 
     @@cache_prefix = 'api::cache::'
+    # Generate cache key.
+    #
+    # @param url [String] unique string of API request
+    # @return [String] Cache key
     def to_key(url)
       "#{@@cache_prefix}#{url}"
     end
 
-    # Generate api_url object for backend API.
+    # Generate URI object for backend API.
     #
-    # @return [URI::HTTP or URI::HTTPS] api_url object for backend API.
+    # @return [URI] URI object of backend API.
     def build_page_values_uri
       api_url = build_api_url('/values')
       t = CGI::escape(@store.settings['user_token'])
@@ -59,6 +78,9 @@ class Wovnrb
       api_url
     end
 
+    # Generate URI object for Project Translation Text Search API.
+    #
+    # @return [URI] URI object of Project Translation Text Search API.
     def build_project_values_uri
       api_url = build_api_url('/project/values')
       srcs = CGI::escape(@srcs.to_json)
@@ -69,6 +91,10 @@ class Wovnrb
       api_url
     end
 
+    # Generate base API URL by api_url setting and path.
+    #
+    # @param path [String] API path
+    # @return [URI] URI object of API URL
     def build_api_url(path)
       api_url = URI.parse(@store.settings['api_url'])
       if md = api_url.path.match(/^\/v\d+/)
@@ -79,6 +105,10 @@ class Wovnrb
       api_url
     end
 
+    # Get HTTP response from API server.
+    #
+    # @param uri [URI] API server URI object
+    # @return [String] Response body of API server request
     def get_from_api_server(uri)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if uri.scheme == 'https'

--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -1,4 +1,4 @@
-module Wovnrb
+class Wovnrb
 
   class Headers
     attr_reader :unmasked_url

--- a/lib/wovnrb/html_replacers/image_replacer.rb
+++ b/lib/wovnrb/html_replacers/image_replacer.rb
@@ -1,4 +1,4 @@
-module Wovnrb
+class Wovnrb
   class ImageReplacer < ReplacerBase
     def initialize(url, text_index, src_index, img_src_prefix)
       @url = url

--- a/lib/wovnrb/html_replacers/link_replacer.rb
+++ b/lib/wovnrb/html_replacers/link_replacer.rb
@@ -1,4 +1,4 @@
-module Wovnrb
+class Wovnrb
   class LinkReplacer < ReplacerBase
     def initialize(pattern, headers)
       @pattern = pattern

--- a/lib/wovnrb/html_replacers/meta_replacer.rb
+++ b/lib/wovnrb/html_replacers/meta_replacer.rb
@@ -1,4 +1,4 @@
-module Wovnrb
+class Wovnrb
   class MetaReplacer < ReplacerBase
     def initialize(text_index)
       @text_index = text_index

--- a/lib/wovnrb/html_replacers/replacer_base.rb
+++ b/lib/wovnrb/html_replacers/replacer_base.rb
@@ -1,4 +1,4 @@
-module Wovnrb
+class Wovnrb
   class ReplacerBase
     def replace(dom, lang)
       raise NotImplementedError.new('replace is not defined')

--- a/lib/wovnrb/html_replacers/script_replacer.rb
+++ b/lib/wovnrb/html_replacers/script_replacer.rb
@@ -1,4 +1,4 @@
-module Wovnrb
+class Wovnrb
   class ScriptReplacer < ReplacerBase
     def initialize(store)
       @store = store

--- a/lib/wovnrb/html_replacers/text_replacer.rb
+++ b/lib/wovnrb/html_replacers/text_replacer.rb
@@ -1,4 +1,4 @@
-module Wovnrb
+class Wovnrb
   class TextReplacer < ReplacerBase
     def initialize(text_index)
       @text_index = text_index

--- a/lib/wovnrb/lang.rb
+++ b/lib/wovnrb/lang.rb
@@ -1,5 +1,5 @@
 # -*- encoding: UTF-8 -*-
-module Wovnrb
+class Wovnrb
   class Lang
     LANG = {
       #http://msdn.microsoft.com/en-us/library/hh456380.aspx

--- a/lib/wovnrb/railtie.rb
+++ b/lib/wovnrb/railtie.rb
@@ -1,4 +1,4 @@
-module Wovnrb
+class Wovnrb
 
   class Railtie < Rails::Railtie
     initializer 'wovnrb.configure_rails_initialization' do |app|

--- a/lib/wovnrb/services/url.rb
+++ b/lib/wovnrb/services/url.rb
@@ -1,4 +1,4 @@
-module Wovnrb
+class Wovnrb
   class URL
     def self.resolve_absolute_url(curr_location, rel_location)
     end

--- a/lib/wovnrb/services/wovn_logger.rb
+++ b/lib/wovnrb/services/wovn_logger.rb
@@ -1,7 +1,7 @@
 require 'singleton'
 require 'logger' unless defined?(Logger)
 
-module Wovnrb
+class Wovnrb
   class WovnLogger
     include Singleton
 

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -26,7 +26,7 @@ class Wovnrb
           'url_pattern' => 'path',
           'url_pattern_reg' => "/(?<lang>[^/.?]+)",
           'query' => [],
-          'api_url' => 'https://api.wovn.io/v0/values',
+          'api_url' => 'https://api.wovn.io/v0',
           'api_timeout_seconds' => 0.5,
           'default_lang' => 'en',
           'supported_langs' => ['en'],

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -4,7 +4,7 @@ require 'cgi'
 require 'singleton'
 require 'wovnrb/services/wovn_logger'
 
-module Wovnrb
+class Wovnrb
   class Store
     include Singleton
 

--- a/lib/wovnrb/text_caches/cache_base.rb
+++ b/lib/wovnrb/text_caches/cache_base.rb
@@ -1,6 +1,6 @@
 require 'active_support/inflector'
 
-module Wovnrb
+class Wovnrb
   class CacheBase
     @@strategy_map = {
         memory: :memory_cache

--- a/lib/wovnrb/text_caches/memory_cache.rb
+++ b/lib/wovnrb/text_caches/memory_cache.rb
@@ -2,7 +2,7 @@ require 'active_support/cache'
 require 'active_support/cache/memory_store'
 require 'lz4-ruby'
 
-module Wovnrb
+class Wovnrb
   class MemoryCache < CacheBase
     @@default_memory_cache_config = {
       cache_megabytes: 200,

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
-module Wovnrb
+class Wovnrb
   VERSION = "0.2.03"
 end

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
-module Wovnrb
+class Wovnrb
   VERSION = "0.2.04"
 end

--- a/test/lib/api_data_test.rb
+++ b/test/lib/api_data_test.rb
@@ -16,78 +16,81 @@ class Wovnrb
     end
 
     def test_initialize
-      Wovnrb::ApiData.new('http://wwww.example.com', Wovnrb::Store.instance)
+      Wovnrb::ApiData.new(Wovnrb::Store.instance)
     end
 
-    def test_get_data
+    def test_get_page_values
       token = 'a'
       url = 'url'
       stub_request(:get, "https://api.wovn.io/v0/values?token=#{token}&url=#{url}").
         to_return(:body => '{"test_body": "a"}')
       store = Wovnrb::Store.instance
       store.settings['user_token'] = token
-      api_data = Wovnrb::ApiData.new(url, store)
+      api_data = Wovnrb::ApiData.new(store)
 
-      assert_equal({'test_body' => 'a'}, api_data.get_data)
+      assert_equal({'test_body' => 'a'}, api_data.get_page_values(url))
     end
 
-    def test_get_data_when_cache_exists
+    def test_get_page_values_when_cache_exists
       token = 'a'
       url = 'url'
       stub = stub_request(:get, "https://api.wovn.io/v0/values?token=#{token}&url=#{url}").
         to_return(:body => '{"test_body": "a"}')
       store = Wovnrb::Store.instance
       store.settings['user_token'] = token
-      api_data = Wovnrb::ApiData.new(url, store)
+      api_data = Wovnrb::ApiData.new(store)
 
-      assert_equal({'test_body' => 'a'}, api_data.get_data)
-      assert_equal({'test_body' => 'a'}, api_data.get_data)
+      assert_equal({'test_body' => 'a'}, api_data.get_page_values(url))
+      assert_equal({'test_body' => 'a'}, api_data.get_page_values(url))
       assert_requested(stub, :times => 1)
     end
 
-    def test_get_data_fail
+    def test_get_page_values_fail
       token = 'a'
       url = 'url'
       stub_request(:get, "https://api.wovn.io/v0/values?token=#{token}&url=#{url}").
         to_return(:status => [500, "Internal Server Error"])
       store = Wovnrb::Store.instance
       store.settings['user_token'] = token
-      api_data = Wovnrb::ApiData.new(url, store)
+      api_data = Wovnrb::ApiData.new(store)
       log_mock = Wovnrb::LogMock.mock_log
 
-      assert_equal({}, api_data.get_data)
+      assert_equal({}, api_data.get_page_values(url))
       assert(log_mock.errors[0].start_with?('API server GET request failed'))
     end
 
-    def test_build_api_uri
+    def test_build_page_values_uri
       token = 'a'
       url = 'url'
       store = Wovnrb::Store.instance
       store.settings['user_token'] = token
-      api_data = Wovnrb::ApiData.new(url, store)
-      api_uri = api_data.send(:build_api_uri)
+      api_data = Wovnrb::ApiData.new(store)
+      api_data.instance_variable_set(:@access_url, url)
+      api_uri = api_data.send(:build_page_values_uri)
       assert_equal('https://api.wovn.io/v0/values?token=a&url=url', api_uri.to_s)
     end
 
-    def test_build_api_uri_with_old_api_url
+    def test_build_page_values_uri_with_old_api_url
       token = 'a'
       url = 'url'
       store = Wovnrb::Store.instance
       store.settings['user_token'] = token
       store.settings['api_url'] = 'https://api.wovn.io/v0/values'
-      api_data = Wovnrb::ApiData.new(url, store)
-      api_uri = api_data.send(:build_api_uri)
+      api_data = Wovnrb::ApiData.new(store)
+      api_data.instance_variable_set(:@access_url, url)
+      api_uri = api_data.send(:build_page_values_uri)
       assert_equal('https://api.wovn.io/v0/values?token=a&url=url', api_uri.to_s)
     end
 
-    def test_build_api_uri_with_non_default_api_url
+    def test_build_page_values_uri_with_non_default_api_url
       token = 'a'
       url = 'url'
       store = Wovnrb::Store.instance
       store.settings['user_token'] = token
       store.settings['api_url'] = 'http://api0.wovn.io/v1'
-      api_data = Wovnrb::ApiData.new(url, store)
-      api_uri = api_data.send(:build_api_uri)
+      api_data = Wovnrb::ApiData.new(store)
+      api_data.instance_variable_set(:@access_url, url)
+      api_uri = api_data.send(:build_page_values_uri)
       assert_equal('http://api0.wovn.io/v1/values?token=a&url=url', api_uri.to_s)
     end
   end

--- a/test/lib/api_data_test.rb
+++ b/test/lib/api_data_test.rb
@@ -58,5 +58,37 @@ class Wovnrb
       assert_equal({}, api_data.get_data)
       assert(log_mock.errors[0].start_with?('API server GET request failed'))
     end
+
+    def test_build_api_uri
+      token = 'a'
+      url = 'url'
+      store = Wovnrb::Store.instance
+      store.settings['user_token'] = token
+      api_data = Wovnrb::ApiData.new(url, store)
+      api_uri = api_data.send(:build_api_uri)
+      assert_equal('https://api.wovn.io/v0/values?token=a&url=url', api_uri.to_s)
+    end
+
+    def test_build_api_uri_with_old_api_url
+      token = 'a'
+      url = 'url'
+      store = Wovnrb::Store.instance
+      store.settings['user_token'] = token
+      store.settings['api_url'] = 'https://api.wovn.io/v0/values'
+      api_data = Wovnrb::ApiData.new(url, store)
+      api_uri = api_data.send(:build_api_uri)
+      assert_equal('https://api.wovn.io/v0/values?token=a&url=url', api_uri.to_s)
+    end
+
+    def test_build_api_uri_with_non_default_api_url
+      token = 'a'
+      url = 'url'
+      store = Wovnrb::Store.instance
+      store.settings['user_token'] = token
+      store.settings['api_url'] = 'http://api0.wovn.io/v1'
+      api_data = Wovnrb::ApiData.new(url, store)
+      api_uri = api_data.send(:build_api_uri)
+      assert_equal('http://api0.wovn.io/v1/values?token=a&url=url', api_uri.to_s)
+    end
   end
 end

--- a/test/lib/api_data_test.rb
+++ b/test/lib/api_data_test.rb
@@ -4,7 +4,7 @@ require 'wovnrb/api_data'
 require 'test_helper'
 require 'webmock/minitest'
 
-module Wovnrb
+class Wovnrb
   class MemoryCacheTest < WovnMiniTest
     def setup
       Wovnrb::CacheBase.set_single({})

--- a/test/lib/api_data_test.rb
+++ b/test/lib/api_data_test.rb
@@ -1,7 +1,7 @@
+require 'test_helper'
 require 'wovnrb/text_caches/cache_base'
 require 'wovnrb/text_caches/memory_cache'
 require 'wovnrb/api_data'
-require 'test_helper'
 require 'webmock/minitest'
 
 class Wovnrb

--- a/test/lib/api_data_test.rb
+++ b/test/lib/api_data_test.rb
@@ -1,4 +1,6 @@
 require 'test_helper'
+require 'cgi'
+require 'json'
 require 'wovnrb/text_caches/cache_base'
 require 'wovnrb/text_caches/memory_cache'
 require 'wovnrb/api_data'
@@ -59,39 +61,74 @@ class Wovnrb
       assert(log_mock.errors[0].start_with?('API server GET request failed'))
     end
 
+    def test_get_project_values
+      token = 'a'
+      srcs = ['Message']
+      host = 'wovn.io'
+      target_lang = 'ja'
+      stub_request(:get, "https://api.wovn.io/v0/project/values?srcs=#{CGI::escape(srcs.to_json)}&host=#{CGI::escape(host)}&target_lang=#{target_lang}&token=#{token}").
+        to_return(:body => '{"results": [{"dst": "メッセージ", "src": "Message"}]}')
+      store = Wovnrb::Store.instance
+      store.settings['user_token'] = token
+      api_data = Wovnrb::ApiData.new(store)
+      assert_equal({'results' => [{'dst' => 'メッセージ', 'src' => 'Message'}]}, api_data.get_project_values(srcs, host, target_lang))
+    end
+
+    def test_build_api_url
+      store = Store.instance
+      api_data = ApiData.new(store)
+      api_url = api_data.send(:build_api_url, '/values')
+      assert_equal('https://api.wovn.io/v0/values', api_url.to_s)
+    end
+
+    def test_build_api_url_with_old_api_url
+      store = Store.instance
+      store.settings['api_url'] = 'https://api.wovn.io/v0/values'
+      api_data = ApiData.new(store)
+      api_url = api_data.send(:build_api_url, '/project/values')
+      assert_equal('https://api.wovn.io/v0/project/values', api_url.to_s)
+    end
+
+    def test_build_api_url_with_non_default_api_url
+      store = Store.instance
+      store.settings['api_url'] = 'http://api0.wovn.io/v1'
+      api_data = ApiData.new(store)
+      api_url = api_data.send(:build_api_url, '/values')
+      assert_equal('http://api0.wovn.io/v1/values', api_url.to_s)
+    end
+
+    def test_build_api_url_with_host_only
+      store = Store.instance
+      store.settings['api_url'] = 'https://api.wovn.io'
+      api_data = ApiData.new(store)
+      api_url = api_data.send(:build_api_url, '/values')
+      assert_equal('https://api.wovn.io/v0/values', api_url.to_s)
+    end
+
     def test_build_page_values_uri
       token = 'a'
       url = 'url'
-      store = Wovnrb::Store.instance
+      store = Store.instance
       store.settings['user_token'] = token
-      api_data = Wovnrb::ApiData.new(store)
+      api_data = ApiData.new(store)
       api_data.instance_variable_set(:@access_url, url)
       api_uri = api_data.send(:build_page_values_uri)
       assert_equal('https://api.wovn.io/v0/values?token=a&url=url', api_uri.to_s)
     end
 
-    def test_build_page_values_uri_with_old_api_url
+    def test_build_project_values_uri
       token = 'a'
-      url = 'url'
-      store = Wovnrb::Store.instance
+      srcs = ['Message']
+      host = 'wovn.io'
+      target_lang = 'ja'
+      store = Store.instance
       store.settings['user_token'] = token
-      store.settings['api_url'] = 'https://api.wovn.io/v0/values'
-      api_data = Wovnrb::ApiData.new(store)
-      api_data.instance_variable_set(:@access_url, url)
-      api_uri = api_data.send(:build_page_values_uri)
-      assert_equal('https://api.wovn.io/v0/values?token=a&url=url', api_uri.to_s)
-    end
-
-    def test_build_page_values_uri_with_non_default_api_url
-      token = 'a'
-      url = 'url'
-      store = Wovnrb::Store.instance
-      store.settings['user_token'] = token
-      store.settings['api_url'] = 'http://api0.wovn.io/v1'
-      api_data = Wovnrb::ApiData.new(store)
-      api_data.instance_variable_set(:@access_url, url)
-      api_uri = api_data.send(:build_page_values_uri)
-      assert_equal('http://api0.wovn.io/v1/values?token=a&url=url', api_uri.to_s)
+      api_data = ApiData.new(store)
+      api_data.instance_variable_set(:@srcs, srcs)
+      api_data.instance_variable_set(:@host, host)
+      api_data.instance_variable_set(:@target_lang, target_lang)
+      api_uri = api_data.send(:build_project_values_uri)
+      assert_equal("https://api.wovn.io/v0/project/values?srcs=#{CGI::escape(srcs.to_json)}&host=#{CGI::escape(host)}&target_lang=#{target_lang}&token=#{token}", api_uri.to_s)
     end
   end
 end

--- a/test/lib/html_replacers/image_replacer_test.rb
+++ b/test/lib/html_replacers/image_replacer_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'webmock/minitest'
 
-module Wovnrb
+class Wovnrb
   class ImageReplacerTest < WovnMiniTest
     def test_replace
       url = {

--- a/test/lib/html_replacers/link_replacer_test.rb
+++ b/test/lib/html_replacers/link_replacer_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'webmock/minitest'
 
-module Wovnrb
+class Wovnrb
   class ReplacerBaseTest < WovnMiniTest
     def test_replace
       replacer = LinkReplacer.new('query', get_header)

--- a/test/lib/html_replacers/meta_replacer_test.rb
+++ b/test/lib/html_replacers/meta_replacer_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'webmock/minitest'
 
-module Wovnrb
+class Wovnrb
   class MetaReplacerTest < WovnMiniTest
     def test_replace_description
       replacer = MetaReplacer.new({

--- a/test/lib/html_replacers/replacer_base_test.rb
+++ b/test/lib/html_replacers/replacer_base_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'webmock/minitest'
 
-module Wovnrb
+class Wovnrb
   class ReplacerBaseTest < WovnMiniTest
     def test_wovn_ignore
       replacer = ReplacerBase.new

--- a/test/lib/html_replacers/script_replacer_test.rb
+++ b/test/lib/html_replacers/script_replacer_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'webmock/minitest'
 
-module Wovnrb
+class Wovnrb
   class ScriptReplacerTest < WovnMiniTest
     def test_replace
       store = Store.instance

--- a/test/lib/html_replacers/text_replacer_test.rb
+++ b/test/lib/html_replacers/text_replacer_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'webmock/minitest'
 
-module Wovnrb
+class Wovnrb
   class TextReplacerTest < WovnMiniTest
     def test_replace
       replacer = TextReplacer.new({

--- a/test/lib/lang_test.rb
+++ b/test/lib/lang_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'minitest/autorun'
 
-module Wovnrb
+class Wovnrb
   class LangTest < WovnMiniTest
 
     def test_langs_exist

--- a/test/lib/services/wovn_logger_test.rb
+++ b/test/lib/services/wovn_logger_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'singleton'
 
-module Wovnrb
+class Wovnrb
   class StoreTest < WovnMiniTest
     def setup
       Singleton.__init__(WovnLogger)

--- a/test/lib/store_test.rb
+++ b/test/lib/store_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require 'test_helper'
 
-module Wovnrb
+class Wovnrb
   class StoreTest < WovnMiniTest
     def test_initialize
       s = Wovnrb::Store.instance

--- a/test/lib/text_caches/cache_base_test.rb
+++ b/test/lib/text_caches/cache_base_test.rb
@@ -2,7 +2,7 @@ require 'wovnrb/text_caches/cache_base'
 require 'minitest/autorun'
 
 class CacheBaseTest < Minitest::Test
-  def teardown
+  def setup
     Wovnrb::CacheBase.reset_cache
   end
 

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+require 'cgi'
+require 'json'
 require 'wovnrb'
 require 'wovnrb/headers'
 require 'minitest/autorun'
@@ -15,6 +17,18 @@ class WovnrbTest < Minitest::Test
     refute_nil(i)
   end
 
+  def test_get_text
+    token = 'a'
+    srcs = ['Message']
+    host = 'wovn.io'
+    target_lang = 'ja'
+    stub_request(:get, "https://api.wovn.io/v0/project/values?srcs=#{CGI::escape(srcs.to_json)}&host=#{CGI::escape(host)}&target_lang=#{target_lang}&token=#{token}").
+      to_return(:body => '{"results": [{"dst": "メッセージ", "src": "Message"}]}')
+    wovnrb = Wovnrb.new
+    wovnrb.instance_variable_get(:@interceptor).store.settings['user_token'] = token
+    results = wovnrb.get_text(srcs, host, target_lang)
+    assert_equal([{'dst' => 'メッセージ', 'src' => 'Message'}], results)
+  end
 
   # def test_call(env)
   # end

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -10,6 +10,12 @@ require 'pry'
 class WovnrbTest < Minitest::Test
   def setup
     Wovnrb::Store.instance.reset
+    Wovnrb::CacheBase.set_single({})
+  end
+
+  def teardown
+    Wovnrb::CacheBase.reset_cache
+    WebMock.reset!
   end
 
   def test_initialize
@@ -28,6 +34,54 @@ class WovnrbTest < Minitest::Test
     wovnrb.instance_variable_get(:@interceptor).store.settings['user_token'] = token
     results = wovnrb.get_text(srcs, host, target_lang)
     assert_equal([{'dst' => 'メッセージ', 'src' => 'Message'}], results)
+  end
+
+  def test_get_text_invalid_arguments
+    token = 'a'
+    wovnrb = Wovnrb.new
+    wovnrb.instance_variable_get(:@interceptor).store.settings['user_token'] = token
+
+    srcs = nil
+    host = nil
+    target_lang = nil
+    assert_raises ArgumentError do
+      wovnrb.get_text(srcs, host, target_lang)
+    end
+
+    srcs = []
+    host = nil
+    target_lang = nil
+    assert_raises ArgumentError do
+      wovnrb.get_text(srcs, host, target_lang)
+    end
+
+    srcs = ['Message']
+    host = nil
+    target_lang = nil
+    assert_raises ArgumentError do
+      wovnrb.get_text(srcs, host, target_lang)
+    end
+
+    srcs = ['Message']
+    host = 'wovn.io'
+    target_lang = nil
+    assert_raises ArgumentError do
+      wovnrb.get_text(srcs, host, target_lang)
+    end
+  end
+
+  def test_get_text_empty_data
+    token = 'a'
+    srcs = ['Message']
+    host = 'wovn.io'
+    target_lang = 'ja'
+    stub_request(:get, "https://api.wovn.io/v0/project/values?srcs=#{CGI::escape(srcs.to_json)}&host=#{CGI::escape(host)}&target_lang=#{target_lang}&token=#{token}").
+      to_return(:status => [500, "Internal Server Error"])
+    wovnrb = Wovnrb.new
+    wovnrb.instance_variable_get(:@interceptor).store.settings['user_token'] = token
+    log_mock = Wovnrb::LogMock.mock_log
+    results = wovnrb.get_text(srcs, host, target_lang)
+    assert_equal(nil, results)
   end
 
   # def test_call(env)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,15 @@
+require 'simplecov'
+
+# save to CircleCI's artifacts directory if we're on CircleCI
+if ENV['CIRCLE_ARTIFACTS']
+  dir = File.join(ENV['CIRCLE_ARTIFACTS'], "coverage")
+  SimpleCov.coverage_dir(dir)
+end
+
+SimpleCov.start do
+  add_filter '/test/'
+end
+
 require 'nokogumbo'
 require 'wovnrb/headers'
 require 'wovnrb/lang'
@@ -9,7 +21,6 @@ require 'wovnrb/html_replacers/meta_replacer'
 require 'wovnrb/html_replacers/image_replacer'
 require 'wovnrb/html_replacers/script_replacer'
 require 'minitest/autorun'
-
 
 class Wovnrb
   class WovnMiniTest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ end
 
 SimpleCov.start do
   add_filter '/test/'
+  track_files 'lib/**/*.rb'
 end
 
 require 'nokogumbo'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require 'wovnrb/html_replacers/script_replacer'
 require 'minitest/autorun'
 
 
-module Wovnrb
+class Wovnrb
   class WovnMiniTest < Minitest::Test
     def before_setup
       super
@@ -38,7 +38,7 @@ module Wovnrb
     end
   end
 
-  def get_settings(options={})
+  def self.get_settings(options={})
     settings = {}
     settings['user_token'] = 'OHYx9'
     settings['url_pattern'] = 'path'
@@ -51,7 +51,7 @@ module Wovnrb
     return settings.merge(options)
   end
 
-  def get_env(options={})
+  def self.get_env(options={})
     env = {}
     env['rack.url_scheme'] = 'http'
     env['HTTP_HOST'] = 'wovn.io'
@@ -82,15 +82,13 @@ module Wovnrb
     return env.merge(options)
   end
 
-  def to_dom(html)
+  def self.to_dom(html)
     dom = Nokogiri::HTML5(html)
     dom.encoding = "UTF-8"
     dom
   end
 
-  def get_dom(innerHTML)
+  def self.get_dom(innerHTML)
     to_dom("<html><body>#{innerHTML}</body></html>")
   end
-
-  module_function :get_env, :get_settings, :to_dom, :get_dom
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,8 @@ end
 
 SimpleCov.start do
   add_filter '/test/'
+  add_filter '/lib/wovnrb/railtie.rb'
+  add_filter '/lib/wovnrb/version.rb'
   track_files 'lib/**/*.rb'
 end
 

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -49,6 +49,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "geminabox"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "webmock"
-
+  spec.add_development_dependency "simplecov"
 end
 


### PR DESCRIPTION
get_text method is for using Project Translation Text Search API. This API is cached and cache key is the query of API request URL.

When you are using Wovnrb::Interceptor, you can use get_text method like following.

``` Ruby
wovnrb = Wovnrb.new
results = wovnrb.get_text(srcs, host, target_lang)
```

When you are not using Wovnrb::Interceptor, you can use get_text method like following.

``` Ruby
wovnrb = Wovnrb.new({
  :user_token => ...,
  :secret => ...,
})
results = wovnrb.get_text(srcs, host, target_lang)
```

Some specification were changed.
- Use query of the request to API server as cache key.
- default api_url setting is 'https://api.wovn.io/v0'.
  - former default value 'https://api.wovn.io/v0/values' can be used too.
