### PR TITLE
Fix sometimes failed test.

### DIFF
--- a/test/lib/text_caches/cache_base_test.rb
+++ b/test/lib/text_caches/cache_base_test.rb
@@ -2,7 +2,7 @@ require 'wovnrb/text_caches/cache_base'
 require 'minitest/autorun'
 
 class CacheBaseTest < Minitest::Test
-  def teardown
+  def setup
     Wovnrb::CacheBase.reset_cache
   end
 


### PR DESCRIPTION
CacheBaseTest#test_get_single_without_set test sometimes fails.

>   1) Failure:
> CacheBaseTest#test_get_single_without_set [/Users/masahiroiuchi/github/wovnrb/test/lib/text_caches/cache_base_test.rb:27]:
> RuntimeError expected but nothing was raised.

It is reproduced by the following command.
> $ bundle exec rake test TESTOPTS="--seed=63769"

* wovnrb tests are done randomly.
* Wovnrb::CacheBase needs not to be initialized for CacheBaseTest#test_get_single_without_set test passing.