### PR TITLE
Update description of wovnrb.gemspec.

### DIFF
--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Jeff Sandford", "Antoine David"]
   spec.email         = ["jeff@wovn.io"]
   spec.summary       = %q{Gem for WOVN.io}
-  spec.description   = %q{ALPHA VERSION, not in a useable form.}
+  spec.description   = %q{Ruby gem for WOVN backend on Rack.}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
It's not alpha version now. The description seems to be displayed on RubyGems.org.
https://rubygems.org/gems/wovnrb