### PR TITLE
Suppress warnings when building gem.

### DIFF
--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["jeff@wovn.io"]
   spec.summary       = %q{Gem for WOVN.io}
   spec.description   = %q{Ruby gem for WOVN backend on Rack.}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/WOVNio/wovnrb"
   spec.license       = "MIT"
 
 
@@ -26,29 +26,29 @@ Gem::Specification.new do |spec|
   #spec.extensions    = spec.files.grep(%r{/extconf\.rb$})
 
   spec.add_dependency "nokogumbo", "1.3.0"
-  spec.add_dependency "activesupport"
-  spec.add_dependency "lz4-ruby"
+  spec.add_dependency "activesupport", "~> 0"
+  spec.add_dependency "lz4-ruby", "~> 0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "listen", "~> 3.0.6"
+  spec.add_development_dependency "listen", "~> 3.0", ">= 3.0.6"
   ##spec.add_development_dependency "mocha"
   #spec.add_development_dependency "rspec"
   #spec.add_development_dependency "rspec-nc"
-  spec.add_development_dependency "test-unit"
-  spec.add_development_dependency "test-unit-notify"
-  spec.add_development_dependency "minitest"
-  spec.add_development_dependency "terminal-notifier"
-  spec.add_development_dependency "guard"
-  spec.add_development_dependency "guard-rspec"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "pry-remote"
-  spec.add_development_dependency "pry-nav"
+  spec.add_development_dependency "test-unit", "~> 0"
+  spec.add_development_dependency "test-unit-notify", "~> 0"
+  spec.add_development_dependency "minitest", "~> 0"
+  spec.add_development_dependency "terminal-notifier", "~> 0"
+  spec.add_development_dependency "guard", "~> 0"
+  spec.add_development_dependency "guard-rspec", "~> 0"
+  spec.add_development_dependency "pry", "~> 0"
+  spec.add_development_dependency "pry-remote", "~> 0"
+  spec.add_development_dependency "pry-nav", "~> 0"
   #spec.add_development_dependency "rice"
-  spec.add_development_dependency "rake-compiler"
-  spec.add_development_dependency "geminabox"
-  spec.add_development_dependency "timecop"
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "rake-compiler", "~> 0"
+  spec.add_development_dependency "geminabox", "~> 0"
+  spec.add_development_dependency "timecop", "~> 0"
+  spec.add_development_dependency "webmock", "~> 0"
 
 end
 

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Jeff Sandford", "Antoine David"]
   spec.email         = ["jeff@wovn.io"]
   spec.summary       = %q{Gem for WOVN.io}
-  spec.description   = %q{ALPHA VERSION, not in a useable form.}
+  spec.description   = %q{Ruby gem for WOVN backend on Rack.}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
Some warnings were output.

```
$ gem build wovnrb.gemspec
WARNING:  no homepage specified
WARNING:  open-ended dependency on activesupport (>= 0) is not recommended
  if activesupport is semantically versioned, use:
    add_runtime_dependency 'activesupport', '~> 0'
WARNING:  open-ended dependency on lz4-ruby (>= 0) is not recommended
  if lz4-ruby is semantically versioned, use:
    add_runtime_dependency 'lz4-ruby', '~> 0'
WARNING:  pessimistic dependency on listen (~> 3.0.6, development) may be overly strict
  if listen is semantically versioned, use:
    add_development_dependency 'listen', '~> 3.0', '>= 3.0.6'
WARNING:  open-ended dependency on test-unit (>= 0, development) is not recommended
  if test-unit is semantically versioned, use:
    add_development_dependency 'test-unit', '~> 0'
WARNING:  open-ended dependency on test-unit-notify (>= 0, development) is not recommended
  if test-unit-notify is semantically versioned, use:
    add_development_dependency 'test-unit-notify', '~> 0'
WARNING:  open-ended dependency on minitest (>= 0, development) is not recommended
  if minitest is semantically versioned, use:
    add_development_dependency 'minitest', '~> 0'
WARNING:  open-ended dependency on terminal-notifier (>= 0, development) is not recommended
  if terminal-notifier is semantically versioned, use:
    add_development_dependency 'terminal-notifier', '~> 0'
WARNING:  open-ended dependency on guard (>= 0, development) is not recommended
  if guard is semantically versioned, use:
    add_development_dependency 'guard', '~> 0'
WARNING:  open-ended dependency on guard-rspec (>= 0, development) is not recommended
  if guard-rspec is semantically versioned, use:
    add_development_dependency 'guard-rspec', '~> 0'
WARNING:  open-ended dependency on pry (>= 0, development) is not recommended
  if pry is semantically versioned, use:
    add_development_dependency 'pry', '~> 0'
WARNING:  open-ended dependency on pry-remote (>= 0, development) is not recommended
  if pry-remote is semantically versioned, use:
    add_development_dependency 'pry-remote', '~> 0'
WARNING:  open-ended dependency on pry-nav (>= 0, development) is not recommended
  if pry-nav is semantically versioned, use:
    add_development_dependency 'pry-nav', '~> 0'
WARNING:  open-ended dependency on rake-compiler (>= 0, development) is not recommended
  if rake-compiler is semantically versioned, use:
    add_development_dependency 'rake-compiler', '~> 0'
WARNING:  open-ended dependency on geminabox (>= 0, development) is not recommended
  if geminabox is semantically versioned, use:
    add_development_dependency 'geminabox', '~> 0'
WARNING:  open-ended dependency on timecop (>= 0, development) is not recommended
  if timecop is semantically versioned, use:
    add_development_dependency 'timecop', '~> 0'
WARNING:  open-ended dependency on webmock (>= 0, development) is not recommended
  if webmock is semantically versioned, use:
    add_development_dependency 'webmock', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: wovnrb
  Version: 0.2.06
  File: wovnrb-0.2.06.gem
```