### PR TITLE
Release gem automatically.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-#require "bundler/gem_tasks"
+require "bundler/gem_tasks"
 #require 'rake/extensiontask'
 require 'rake/testtask'
 require 'pry'

--- a/circle.yml
+++ b/circle.yml
@@ -6,3 +6,8 @@ test:
   override:
     - bundle exec rake test
 
+deployment:
+  rubygems:
+    branch: master
+    commands:
+      - bash ./release.sh

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+version_file=lib/wovnrb/version.rb
+
+if [ -z "$CIRCLECI" ]; then
+  echo "This script runs only on CircleCI"
+  exit
+fi
+
+changed_files=`git diff --name-only HEAD~`
+is_version_file_changed=`echo $changed_files | grep $version_file`
+if [ -z "$is_version_file_changed" ]; then
+  echo "This commit does not change $version_file"
+  exit
+fi
+
+curl -u $RUBYGEMS_USERNAME:$RUBYGEMS_PASSWORD https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials; chmod 0600 ~/.gem/credentials
+git config user.name $GITHUB_USERNAME
+git config user.email $GITHUB_EMAIL
+bundle exec rake build
+bundle exec rake release


### PR DESCRIPTION
Release gem to RubyGems.org automatically by CircleCI after pushing a commit to master branch and the commit's changing lib/wovnrb/version.rb.

I have checked this in my private project (https://github.com/masiuchi/rack-conditional) already. But I have not checked this wovnrb yet. I will check it after merging this pull request.