### PR TITLE
Hotfix/travis ruby 1.9.3 tests

### DIFF
--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", "< 5"
   spec.add_dependency "lz4-ruby"
 
-  spec.add_development_dependency 'public_suffix', '~> 1.4.6'
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "listen", "~> 3.0.6"
@@ -49,7 +48,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "geminabox"
   spec.add_development_dependency "timecop"
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "webmock", '~> 2.1.0'
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency 'public_suffix', '~> 1.4.6'
 end
 

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", "< 5"
   spec.add_dependency "lz4-ruby"
 
+  spec.add_development_dependency 'public_suffix', '~> 1.4.6'
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "listen", "~> 3.0.6"


### PR DESCRIPTION
Ruby 1.9.3 tests were failing because of some gems update.
To maintain Ruby 1.9.3 compatibility I pined down the compatible version of the gems that were causing problems.