### PR TITLE
Feature/fragmented values swapping wovn ignore

### DIFF
--- a/lib/wovnrb/html_replacers/html_text_replacer.rb
+++ b/lib/wovnrb/html_replacers/html_text_replacer.rb
@@ -73,6 +73,7 @@ module Wovnrb
     # @param [Nokogiri::XML::Node] dst_node The node with the content to put in
     #                                       the src_node.
     def swap_complex_val(src_node, dst_node)
+      return if src_node.has_attribute?('wovn-ignore')
       align_nodes(src_node, dst_node)
       src_node_children = src_node.children
       dst_node_children = dst_node.children

--- a/lib/wovnrb/html_replacers/html_text_scraper.rb
+++ b/lib/wovnrb/html_replacers/html_text_scraper.rb
@@ -105,6 +105,7 @@ module Wovnrb
     def node_to_src(node, complex, surround=false)
       src = ''
       tag_name = node.name.downcase
+      wovn_ignore = node.has_attribute?('wovn-ignore')
 
       # specific cases
       if tag_name == 'text'
@@ -123,7 +124,7 @@ module Wovnrb
       end
 
       if surround
-        format_tag(tag_name, content)
+        format_tag(tag_name, content, wovn_ignore)
       else
         content
       end
@@ -138,8 +139,12 @@ module Wovnrb
     end
 
     private
-    def format_tag(name, content)
-      "<#{name}>#{content}</#{name}>"
+    def format_tag(name, content, wovn_ignore=false)
+      if wovn_ignore
+        "<#{name} wovn-ignore></#{name}>"
+      else
+        "<#{name}>#{content}</#{name}>"
+      end
     end
 
     def format_standalone_tag(name)

--- a/test/lib/html_replacers/html_text_replacer_test.rb
+++ b/test/lib/html_replacers/html_text_replacer_test.rb
@@ -153,5 +153,32 @@ module Wovnrb
       inner_html = dom.xpath('//p')[0].inner_html
       assert_equal('<a>こんにちは World!</a>', inner_html)
     end
+
+    def test_replace_with_complex_value_wovn_ignore_dst_unballanced_right_alignment
+      replacer = HTMLTextReplacer.new({}, {
+        'Hello<a wovn-ignore></a>' => {'ja' => [{'data' => 'こんにちは<a wovn-ignore></a>!'}]}
+      })
+
+      dom = Wovnrb.get_dom('<p>Hello <a wovn-ignore>World</a></p>')
+      replacer.replace(dom, Lang.new('ja'))
+
+      inner_html = dom.xpath('//p')[0].inner_html
+      assert_equal('こんにちは<a wovn-ignore="">World</a>!', inner_html)
+    end
+
+    def test_replace_multiple_with_complex_value_wovn_ignore
+      replacer = HTMLTextReplacer.new({}, {
+        'Hello<a>World</a>' => {'ja' => [{'data' => 'こんにちは<a>World</a>'}]},
+        'Another Hello<a wovn-ignore></a>' => {'ja' => [{'data' => 'こんにちはanother<a wovn-ignore></a>'}]},
+      })
+
+      dom = Wovnrb.get_dom('<p>Hello <a>World</a></p><p>Another Hello <a wovn-ignore>World ;)</a></p>')
+      replacer.replace(dom, Lang.new('ja'))
+
+      inner_html_1 = dom.xpath('//p')[0].inner_html
+      inner_html_2 = dom.xpath('//p')[1].inner_html
+      assert_equal('こんにちは<a>World</a>', inner_html_1)
+      assert_equal('こんにちはanother<a wovn-ignore="">World ;)</a>', inner_html_2)
+    end
   end
 end

--- a/test/lib/html_replacers/html_text_scraper_test.rb
+++ b/test/lib/html_replacers/html_text_scraper_test.rb
@@ -186,6 +186,20 @@ module Wovnrb
       assert_equal('<a>hello</a>', src)
     end
 
+    def test_node_to_src_with_nest_wovn_ignore
+      node = create_node('<div>hello<a wovn-ignore>world</a>welcome</div>')
+      src = @scraper.node_to_src(node, false, false)
+
+      assert_equal('hello<a wovn-ignore></a>welcome', src)
+    end
+
+    def test_node_to_src_with_nest_two_wovn_ignore
+      node = create_node('<div>hello<a wovn-ignore>world</a>welcome<span wovn-ignore>again</span></div>')
+      src = @scraper.node_to_src(node, false, false)
+
+      assert_equal('hello<a wovn-ignore></a>welcome<span wovn-ignore></span>', src)
+    end
+
     def test_get_node_text
       node = create_node('hello&lt;&gt;world')
       assert_equal('hello<>world', node.text)

--- a/test/lib/html_replacers/image_replacer_test.rb
+++ b/test/lib/html_replacers/image_replacer_test.rb
@@ -45,7 +45,7 @@ module Wovnrb
 
       img = dom.xpath('//img')[0]
       assert_equal('http://test.com/ttt.img', img.get_attribute('src'))
-      assert_equal(nil, img.previous)
+      assert_nil(img.previous)
     end
 
     def test_replace_root_path
@@ -65,7 +65,7 @@ module Wovnrb
 
       img = dom.xpath('//img')[0]
       assert_equal('http://test.com/ttt.img', img.get_attribute('src'))
-      assert_equal(nil, img.previous)
+      assert_nil(img.previous)
     end
 
     def test_replace_absolute_path
@@ -85,7 +85,7 @@ module Wovnrb
 
       img = dom.xpath('//img')[0]
       assert_equal('http://test.com/ttt.img', img.get_attribute('src'))
-      assert_equal(nil, img.previous)
+      assert_nil(img.previous)
     end
   end
 end

--- a/test/lib/html_replacers/text_replacer_test.rb
+++ b/test/lib/html_replacers/text_replacer_test.rb
@@ -44,7 +44,7 @@ module Wovnrb
 
       node = dom.xpath('//text()')[0]
       assert_equal('Hello', node.content)
-      assert_equal(nil, node.previous)
+      assert_nil(node.previous)
     end
   end
 end

--- a/test/lib/lang_test.rb
+++ b/test/lib/lang_test.rb
@@ -70,15 +70,15 @@ module Wovnrb
     end
 
     def test_get_code_with_invalid_name
-      assert_equal(nil, Wovnrb::Lang.get_code('WOVN4LYFE'))
+      assert_nil(Wovnrb::Lang.get_code('WOVN4LYFE'))
     end
 
     def test_get_code_with_empty_string
-      assert_equal(nil, Wovnrb::Lang.get_code(''))
+      assert_nil(Wovnrb::Lang.get_code(''))
     end
 
     def test_get_code_with_nil
-      assert_equal(nil, Wovnrb::Lang.get_code(nil))
+      assert_nil(Wovnrb::Lang.get_code(nil))
     end
 
     def test_add_lang_code
@@ -204,7 +204,7 @@ module Wovnrb
     def test_add_lang_code_nil_href
       lang = Lang.new('en')
       h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://favy.tips'), Wovnrb.get_settings)
-      assert_equal(nil, lang.add_lang_code(nil,'path', h))
+      assert_nil(lang.add_lang_code(nil,'path', h))
     end
     def test_add_lang_code_absolute_different_host
       lang = Lang.new('fr')

--- a/test/lib/text_caches/memory_cache_test.rb
+++ b/test/lib/text_caches/memory_cache_test.rb
@@ -62,7 +62,7 @@ class MemoryCacheTest < Minitest::Test
 
   def test_get_without_cache
     memory = Wovnrb::MemoryCache.new({})
-    assert_equal(nil, memory.get('a'))
+    assert_nil(memory.get('a'))
 
   end
 
@@ -70,7 +70,7 @@ class MemoryCacheTest < Minitest::Test
     memory = Wovnrb::MemoryCache.new({})
     memory.put('a', 'b')
     Timecop.travel(1.day.since)
-    assert_equal(nil, memory.get('a'))
+    assert_nil(memory.get('a'))
   end
 
   def test_get_with_over_memory
@@ -80,7 +80,7 @@ class MemoryCacheTest < Minitest::Test
     })
     memory.put('a', 'c')
     memory.put('b', 'd')
-    assert_equal(nil, memory.get('a'))
+    assert_nil(memory.get('a'))
     assert_equal('d', memory.get('b'))
   end
 

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri", "< 1.6.8.1"
   spec.add_dependency "activesupport", "< 5"
   spec.add_dependency "lz4-ruby"
-  spec.add_dependency 'nokogiri', '~> 1.6.8'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Purpose/goal of PR (Issue #)
Handle unified values container tags with wovn-ignore
- Find the correct value (empty the wovn-ignore content to use the index)
- Do not swap wovn-ignore pieces