### PR TITLE
Fix assert warnings.

### DIFF
--- a/test/lib/html_replacers/image_replacer_test.rb
+++ b/test/lib/html_replacers/image_replacer_test.rb
@@ -45,7 +45,7 @@ module Wovnrb
 
       img = dom.xpath('//img')[0]
       assert_equal('http://test.com/ttt.img', img.get_attribute('src'))
-      assert_equal(nil, img.previous)
+      assert_nil(img.previous)
     end
 
     def test_replace_root_path
@@ -65,7 +65,7 @@ module Wovnrb
 
       img = dom.xpath('//img')[0]
       assert_equal('http://test.com/ttt.img', img.get_attribute('src'))
-      assert_equal(nil, img.previous)
+      assert_nil(img.previous)
     end
 
     def test_replace_absolute_path
@@ -85,7 +85,7 @@ module Wovnrb
 
       img = dom.xpath('//img')[0]
       assert_equal('http://test.com/ttt.img', img.get_attribute('src'))
-      assert_equal(nil, img.previous)
+      assert_nil(img.previous)
     end
   end
 end

--- a/test/lib/html_replacers/text_replacer_test.rb
+++ b/test/lib/html_replacers/text_replacer_test.rb
@@ -44,7 +44,7 @@ module Wovnrb
 
       node = dom.xpath('//text()')[0]
       assert_equal('Hello', node.content)
-      assert_equal(nil, node.previous)
+      assert_nil(node.previous)
     end
   end
 end

--- a/test/lib/lang_test.rb
+++ b/test/lib/lang_test.rb
@@ -70,15 +70,15 @@ module Wovnrb
     end
 
     def test_get_code_with_invalid_name
-      assert_equal(nil, Wovnrb::Lang.get_code('WOVN4LYFE'))
+      assert_nil(Wovnrb::Lang.get_code('WOVN4LYFE'))
     end
 
     def test_get_code_with_empty_string
-      assert_equal(nil, Wovnrb::Lang.get_code(''))
+      assert_nil(Wovnrb::Lang.get_code(''))
     end
 
     def test_get_code_with_nil
-      assert_equal(nil, Wovnrb::Lang.get_code(nil))
+      assert_nil(Wovnrb::Lang.get_code(nil))
     end
 
     def test_add_lang_code
@@ -204,7 +204,7 @@ module Wovnrb
     def test_add_lang_code_nil_href
       lang = Lang.new('en')
       h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://favy.tips'), Wovnrb.get_settings)
-      assert_equal(nil, lang.add_lang_code(nil,'path', h))
+      assert_nil(lang.add_lang_code(nil,'path', h))
     end
     def test_add_lang_code_absolute_different_host
       lang = Lang.new('fr')

--- a/test/lib/text_caches/memory_cache_test.rb
+++ b/test/lib/text_caches/memory_cache_test.rb
@@ -62,7 +62,7 @@ class MemoryCacheTest < Minitest::Test
 
   def test_get_without_cache
     memory = Wovnrb::MemoryCache.new({})
-    assert_equal(nil, memory.get('a'))
+    assert_nil(memory.get('a'))
 
   end
 
@@ -70,7 +70,7 @@ class MemoryCacheTest < Minitest::Test
     memory = Wovnrb::MemoryCache.new({})
     memory.put('a', 'b')
     Timecop.travel(1.day.since)
-    assert_equal(nil, memory.get('a'))
+    assert_nil(memory.get('a'))
   end
 
   def test_get_with_over_memory
@@ -80,7 +80,7 @@ class MemoryCacheTest < Minitest::Test
     })
     memory.put('a', 'c')
     memory.put('b', 'd')
-    assert_equal(nil, memory.get('a'))
+    assert_nil(memory.get('a'))
     assert_equal('d', memory.get('b'))
   end
 


### PR DESCRIPTION
Warning is this.

```
bundle exec rake test
Run options: -p --seed 53044

# Running:

***************************************************Use assert_nil if expecting nil from wovnrb/test/lib/html_replacers/image_replacer_test.rb:88:in `test_replace_absolute_path'. This will fail in MT6.
*Use assert_nil if expecting nil from wovnrb/test/lib/html_replacers/image_replacer_test.rb:68:in `test_replace_root_path'. This will fail in MT6.
*Use assert_nil if expecting nil from wovnrb/test/lib/html_replacers/image_replacer_test.rb:48:in `test_replace_relative_path'. This will fail in MT6.
************Use assert_nil if expecting nil from wovnrb/test/lib/lang_test.rb:207:in `test_add_lang_code_nil_href'. This will fail in MT6.
*********Use assert_nil if expecting nil from wovnrb/test/lib/lang_test.rb:81:in `test_get_code_with_nil'. This will fail in MT6.
**************Use assert_nil if expecting nil from wovnrb/test/lib/lang_test.rb:77:in `test_get_code_with_empty_string'. This will fail in MT6.
*********Use assert_nil if expecting nil from wovnrb/test/lib/lang_test.rb:73:in `test_get_code_with_invalid_name'. This will fail in MT6.
*****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************Use assert_nil if expecting nil from wovnrb/test/lib/html_replacers/text_replacer_test.rb:47:in `test_replace_wovn_ignore'. This will fail in MT6.
**Use assert_nil if expecting nil from wovnrb/test/lib/text_caches/memory_cache_test.rb:83:in `test_get_with_over_memory'. This will fail in MT6.
****Use assert_nil if expecting nil from wovnrb/test/lib/text_caches/memory_cache_test.rb:65:in `test_get_without_cache'. This will fail in MT6.
***Use assert_nil if expecting nil from wovnrb/test/lib/text_caches/memory_cache_test.rb:73:in `test_get_with_timeout'. This will fail in MT6.
**************************

Fabulous run in 0.411345s, 3279.4834 runs/s, 4217.8678 assertions/s.

1349 runs, 1735 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to coverage. 531 / 601 LOC (88.35%) covered.
```