### PR TITLE
Fix to work with sinatra

### DIFF
--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -4,6 +4,8 @@ require 'cgi'
 require 'singleton'
 require 'wovnrb/services/wovn_logger'
 require 'wovnrb/services/glob'
+require 'active_support'
+require 'active_support/core_ext'
 
 module Wovnrb
   class Store


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)

Hash.stringify_keys! method is extend by ActiveSupport.
So need add require 'active_support/core_ext'.

### Comments

Pass test case, but this error displayed with sinatra.
Because `require 'active_support/core_ext'` is running somewhere only in the test.

```
Boot Error

Something went wrong while loading config.ru

NoMethodError: undefined method `stringify_keys!' for {"ja"=>"staging-ja"}:Hash

/home/hiroshi/git/wovn/wovnrb/lib/wovnrb/store.rb:146:in `settings'
/home/hiroshi/git/wovn/wovnrb/lib/wovnrb.rb:25:in `initialize'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/builder.rb:86:in `new'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/builder.rb:86:in `block in use'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/builder.rb:147:in `[]'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/builder.rb:147:in `block in to_app'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/builder.rb:147:in `each'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/builder.rb:147:in `inject'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/builder.rb:147:in `to_app'
config.ru:17:in `inner_app'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:113:in `eval'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:113:in `inner_app'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:103:in `assemble_app'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:86:in `proceed_as_child'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:31:in `call!'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:18:in `call'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/shotgun-0.9.2/lib/shotgun/favicon.rb:12:in `call'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/shotgun-0.9.2/lib/shotgun/static.rb:14:in `call'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/urlmap.rb:66:in `block in call'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/urlmap.rb:50:in `each'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/urlmap.rb:50:in `call'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/builder.rb:153:in `call'
/home/hiroshi/git/wovn/wovnrb-sinatra/vendor/bundle/ruby/2.1.0/gems/rack-1.6.5/lib/rack/handler/webrick.rb:88:in `service'
/home/hiroshi/.rbenv/versions/2.1.0/lib/ruby/2.1.0/webrick/httpserver.rb:138:in `service'
/home/hiroshi/.rbenv/versions/2.1.0/lib/ruby/2.1.0/webrick/httpserver.rb:94:in `run'
/home/hiroshi/.rbenv/versions/2.1.0/lib/ruby/2.1.0/webrick/server.rb:295:in `block in start_thread'
```
