### PR TITLE
Fix segmentation introduced with release 0.2.11.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,6 @@ machine:
     version: 2.3.0
 
 test:
-  pre:
   override:
     - bundle exec rake test
     # check that no crash occurs with earlier version of nokogiri

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,11 @@ machine:
     version: 2.3.0
 
 test:
+  pre:
   override:
+    - bundle exec rake test
+    # check that no crash occurs with earlier version of nokogiri
+    - echo "gem 'nokogiri', '1.6.1'" >> Gemfile
+    - bundle update nokogiri
     - bundle exec rake test
 

--- a/lib/wovnrb/html_replacers/replacer_base.rb
+++ b/lib/wovnrb/html_replacers/replacer_base.rb
@@ -18,7 +18,7 @@ module Wovnrb
     # <title> may not contain other markup, so add comment-node to node's previous
     # @see https://www.w3.org/TR/html401/struct/global.html#h-7.4.2
     def add_comment_node(node, text)
-      comment_node = Nokogiri::XML::Comment.new(node, "wovn-src:#{text}")
+      comment_node = Nokogiri::XML::Comment.new(node.document, "wovn-src:#{text}")
       if node.parent.name == 'title'
         node.parent.add_previous_sibling(comment_node)
       else

--- a/test/lib/html_replacers/replacer_base_test.rb
+++ b/test/lib/html_replacers/replacer_base_test.rb
@@ -48,12 +48,16 @@ module Wovnrb
 
     def test_add_comment_node
       replacer = ReplacerBase.new
-      html = Nokogiri::HTML("<html><body><h1 id=\"test-node\">Test Content</h1></body></html>")
+      html = Nokogiri::HTML5('<html><body><h1 id="test-node">Test Content</h1></body></html>')
       h1 = html.xpath("//h1[@id='test-node']")[0]
-      text_node = h1.children[0]
 
-      assert_equal("Test Content", h1.inner_html)
-      replacer.send(:add_comment_node, text_node, 'test content')
+      assert_equal('Test Content', h1.inner_html)
+      h1.xpath('//text()').each do |node|
+        text_content = node.content
+        if text_content == 'Test Content'
+          replacer.send(:add_comment_node, node, 'test content')
+        end
+      end
       assert_equal("<!--wovn-src:test content-->Test Content", h1.inner_html)
     end
   end

--- a/test/lib/html_replacers/replacer_base_test.rb
+++ b/test/lib/html_replacers/replacer_base_test.rb
@@ -45,6 +45,17 @@ module Wovnrb
       actual = replacer.send(:replace_text, "    Hello  \n   Hello    ", 'こんにちは')
       assert_equal('    こんにちは    ', actual)
     end
+
+    def test_add_comment_node
+      replacer = ReplacerBase.new
+      html = Nokogiri::HTML("<html><body><h1 id=\"test-node\">Test Content</h1></body></html>")
+      h1 = html.xpath("//h1[@id='test-node']")[0]
+      text_node = h1.children[0]
+
+      assert_equal("Test Content", h1.inner_html)
+      replacer.send(:add_comment_node, text_node, 'test content')
+      assert_equal("<!--wovn-src:test content-->Test Content", h1.inner_html)
+    end
   end
 end
 


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Related to:
- Segmentation fault when creating `wovn-src` comment node

### Comments
Creating a comment node needs to be done from the node's document instead
of the node itself.