### PR TITLE
Feature/dev mode

### DIFF
--- a/lib/wovnrb/html_replacers/script_replacer.rb
+++ b/lib/wovnrb/html_replacers/script_replacer.rb
@@ -23,7 +23,7 @@ module Wovnrb
 
       # INSERT BACKEND WIDGET
       insert_node = Nokogiri::XML::Node.new('script', dom)
-      insert_node['src'] = '//j.wovn.io/1'
+      insert_node['src'] = "//j.#{@store.wovn_host}/1"
       insert_node['async'] = true
       version = defined?(VERSION) ? VERSION : ''
       insert_node['data-wovnio'] = "key=#{@store.settings['user_token']}&backend=true&currentLang=#{lang.lang_code}&defaultLang=#{@store.settings['default_lang']}&urlPattern=#{@store.settings['url_pattern']}&langCodeAliases=#{JSON.dump(@store.settings['custom_lang_aliases'])}&version=#{version}"

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -40,7 +40,7 @@ module Wovnrb
           'ttl_seconds' => nil,
           'use_proxy' => false,  # use env['HTTP_X_FORWARDED_HOST'] instead of env['HTTP_HOST'] and env['SERVER_NAME'] when this setting is true.
           'custom_lang_aliases' => {},
-          'dev_mode' => false
+          'wovn_dev_mode' => false
         }
       # When Store is initialized, the Rails.configuration object is not yet initialized
       @config_loaded = false
@@ -149,7 +149,7 @@ module Wovnrb
         @settings['custom_lang_aliases'].stringify_keys!
       end
 
-      if dev_mode? && @settings['api_url'].blank?
+      if wovn_dev_mode? && @settings['api_url'].blank?
         @settings['api_url'] = "#{wovn_protocol}://api.#{wovn_host}/v0/values"
       end
 
@@ -161,16 +161,16 @@ module Wovnrb
       @settings
     end
 
-    def dev_mode?
-      @settings['dev_mode']
+    def wovn_dev_mode?
+      @settings['wovn_dev_mode']
     end
 
     def wovn_protocol
-      dev_mode? ? 'http' : 'https'
+      wovn_dev_mode? ? 'http' : 'https'
     end
 
     def wovn_host
-      dev_mode? ? 'dev-wovn.io:3000' : 'wovn.io'
+      wovn_dev_mode? ? 'dev-wovn.io:3000' : 'wovn.io'
     end
 
     private

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -30,7 +30,7 @@ module Wovnrb
           'url_pattern' => 'path',
           'url_pattern_reg' => "/(?<lang>[^/.?]+)",
           'query' => [],
-          'api_url' => 'https://api.wovn.io/v0/values',
+          'api_url' => '',
           'api_timeout_seconds' => 0.5,
           'default_lang' => 'en',
           'supported_langs' => ['en'],
@@ -39,7 +39,8 @@ module Wovnrb
           'cache_megabytes' => nil,
           'ttl_seconds' => nil,
           'use_proxy' => false,  # use env['HTTP_X_FORWARDED_HOST'] instead of env['HTTP_HOST'] and env['SERVER_NAME'] when this setting is true.
-          'custom_lang_aliases' => {}
+          'custom_lang_aliases' => {},
+          'dev_mode' => false
         }
       # When Store is initialized, the Rails.configuration object is not yet initialized
       @config_loaded = false
@@ -148,8 +149,28 @@ module Wovnrb
         @settings['custom_lang_aliases'].stringify_keys!
       end
 
+      if valid_dev_mode? && @settings['api_url'].blank?
+        @settings['api_url'] = "#{wovn_protocol}://api.#{wovn_host}/v0/values"
+      end
+
+      if @settings['api_url'].blank?
+        @settings['api_url'] = 'https://api.wovn.io/v0/values'
+      end
+
       @config_loaded = true
       @settings
+    end
+
+    def valid_dev_mode?
+      @settings['dev_mode'] && Rails.env.development?
+    end
+
+    def wovn_protocol
+      valid_dev_mode? ? 'http' : 'https'
+    end
+
+    def wovn_host
+      valid_dev_mode? ? 'dev-wovn.io:3000' : 'wovn.io'
     end
 
     private

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -11,6 +11,29 @@ module Wovnrb
   class Store
     include Singleton
 
+    def self.default_settings
+      {
+        'user_token' => '',
+        'log_path' => 'log/wovn_error.log',
+        'ignore_paths' => [],
+        'ignore_globs' => [],
+        'url_pattern' => 'path',
+        'url_pattern_reg' => "/(?<lang>[^/.?]+)",
+        'query' => [],
+        'api_url' => 'https://api.wovn.io/v0/values',
+        'api_timeout_seconds' => 0.5,
+        'default_lang' => 'en',
+        'supported_langs' => ['en'],
+        'test_mode' => false,
+        'test_url' => '',
+        'cache_megabytes' => nil,
+        'ttl_seconds' => nil,
+        'use_proxy' => false,  # use env['HTTP_X_FORWARDED_HOST'] instead of env['HTTP_HOST'] and env['SERVER_NAME'] when this setting is true.
+        'custom_lang_aliases' => {},
+        'wovn_dev_mode' => false
+      }
+    end
+
     def initialize
       @settings = {}
       @config_loaded = false
@@ -21,27 +44,7 @@ module Wovnrb
     #
     # @return [nil]
     def reset
-      @settings =
-        {
-          'user_token' => '',
-          'log_path' => 'log/wovn_error.log',
-          'ignore_paths' => [],
-          'ignore_globs' => [],
-          'url_pattern' => 'path',
-          'url_pattern_reg' => "/(?<lang>[^/.?]+)",
-          'query' => [],
-          'api_url' => '',
-          'api_timeout_seconds' => 0.5,
-          'default_lang' => 'en',
-          'supported_langs' => ['en'],
-          'test_mode' => false,
-          'test_url' => '',
-          'cache_megabytes' => nil,
-          'ttl_seconds' => nil,
-          'use_proxy' => false,  # use env['HTTP_X_FORWARDED_HOST'] instead of env['HTTP_HOST'] and env['SERVER_NAME'] when this setting is true.
-          'custom_lang_aliases' => {},
-          'wovn_dev_mode' => false
-        }
+      @settings = Store.default_settings
       # When Store is initialized, the Rails.configuration object is not yet initialized
       @config_loaded = false
     end
@@ -149,12 +152,8 @@ module Wovnrb
         @settings['custom_lang_aliases'].stringify_keys!
       end
 
-      if wovn_dev_mode? && @settings['api_url'].blank?
+      if wovn_dev_mode? && @settings['api_url'] == Store.default_settings['api_url']
         @settings['api_url'] = "#{wovn_protocol}://api.#{wovn_host}/v0/values"
-      end
-
-      if @settings['api_url'].blank?
-        @settings['api_url'] = 'https://api.wovn.io/v0/values'
       end
 
       @config_loaded = true

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -149,7 +149,7 @@ module Wovnrb
         @settings['custom_lang_aliases'].stringify_keys!
       end
 
-      if valid_dev_mode? && @settings['api_url'].blank?
+      if dev_mode? && @settings['api_url'].blank?
         @settings['api_url'] = "#{wovn_protocol}://api.#{wovn_host}/v0/values"
       end
 
@@ -161,16 +161,16 @@ module Wovnrb
       @settings
     end
 
-    def valid_dev_mode?
-      @settings['dev_mode'] && Rails.env.development?
+    def dev_mode?
+      @settings['dev_mode']
     end
 
     def wovn_protocol
-      valid_dev_mode? ? 'http' : 'https'
+      dev_mode? ? 'http' : 'https'
     end
 
     def wovn_host
-      valid_dev_mode? ? 'dev-wovn.io:3000' : 'wovn.io'
+      dev_mode? ? 'dev-wovn.io:3000' : 'wovn.io'
     end
 
     private

--- a/test/lib/html_replacers/script_replacer_test.rb
+++ b/test/lib/html_replacers/script_replacer_test.rb
@@ -23,12 +23,12 @@ module Wovnrb
       assert_equal('test/test.js', other_script.get_attribute('src'))
     end
 
-    def test_replace_with_dev_mode_on
+    def test_replace_with_wovn_dev_mode_on
       store = Store.instance
       store.settings['user_token'] = 'test_token'
       store.settings['default_lang'] = 'en'
       store.settings['url_pattern'] = 'domain'
-      store.settings['dev_mode'] = true
+      store.settings['wovn_dev_mode'] = true
 
       replacer = ScriptReplacer.new(store)
       dom = to_head_dom('<script src="test/test.js"></script>')

--- a/test/lib/html_replacers/script_replacer_test.rb
+++ b/test/lib/html_replacers/script_replacer_test.rb
@@ -23,6 +23,27 @@ module Wovnrb
       assert_equal('test/test.js', other_script.get_attribute('src'))
     end
 
+    def test_replace_with_dev_mode_on
+      store = Store.instance
+      store.settings['user_token'] = 'test_token'
+      store.settings['default_lang'] = 'en'
+      store.settings['url_pattern'] = 'domain'
+      store.settings['dev_mode'] = true
+
+      replacer = ScriptReplacer.new(store)
+      dom = to_head_dom('<script src="test/test.js"></script>')
+      replacer.replace(dom, Lang.new('ja'))
+
+      scripts = dom.xpath('//script')
+      assert_equal(2, scripts.length)
+
+      wovn_script = scripts[0]
+      other_script = scripts[1]
+
+      assert_equal('//j.dev-wovn.io:3000/1', wovn_script.get_attribute('src'))
+      assert_equal('test/test.js', other_script.get_attribute('src'))
+    end
+
     def test_with_embed_wovn
       store = Store.instance
       store.settings['user_token'] = 'test_token'

--- a/test/lib/store_test.rb
+++ b/test/lib/store_test.rb
@@ -112,46 +112,46 @@ module Wovnrb
       assert_equal({'ja' => 'staging-ja', 'en' => 'staging-en'}, s.settings['custom_lang_aliases'])
     end
 
-    def test_dev_mode_on
+    def test_wovn_dev_mode_on
       s = Wovnrb::Store.instance
-      s.settings({'dev_mode' => true})
+      s.settings({'wovn_dev_mode' => true})
 
-      assert(s.settings['dev_mode'])
-      assert(s.dev_mode?)
+      assert(s.settings['wovn_dev_mode'])
+      assert(s.wovn_dev_mode?)
     end
 
-    def test_dev_mode_off_by_default
+    def test_wovn_dev_mode_off_by_default
       s = Wovnrb::Store.instance
       s.settings({})
 
-      assert(!s.settings['dev_mode'])
-      assert(!s.dev_mode?)
+      assert(!s.settings['wovn_dev_mode'])
+      assert(!s.wovn_dev_mode?)
     end
 
-    def test_default_api_url_with_dev_mode_on
+    def test_default_api_url_with_wovn_dev_mode_on
       s = Wovnrb::Store.instance
-      s.settings({'dev_mode' => true})
+      s.settings({'wovn_dev_mode' => true})
 
       assert_equal('http://api.dev-wovn.io:3000/v0/values', s.settings['api_url'])
     end
 
-    def test_default_api_url_with_dev_mode_off
+    def test_default_api_url_with_wovn_dev_mode_off
       s = Wovnrb::Store.instance
-      s.settings({'dev_mode' => false})
+      s.settings({'wovn_dev_mode' => false})
 
       assert_equal('https://api.wovn.io/v0/values', s.settings['api_url'])
     end
 
-    def test_custom_api_url_not_changed_with_dev_mode_on
+    def test_custom_api_url_not_changed_with_wovn_dev_mode_on
       s = Wovnrb::Store.instance
-      s.settings({'api_url' => 'test-api.io', 'dev_mode' => true})
+      s.settings({'api_url' => 'test-api.io', 'wovn_dev_mode' => true})
 
       assert_equal('test-api.io', s.settings['api_url'])
     end
 
-    def test_custom_api_url_not_changed_with_dev_mode_off
+    def test_custom_api_url_not_changed_with_wovn_dev_mode_off
       s = Wovnrb::Store.instance
-      s.settings({'api_url' => 'test-api.io', 'dev_mode' => false})
+      s.settings({'api_url' => 'test-api.io', 'wovn_dev_mode' => false})
 
       assert_equal('test-api.io', s.settings['api_url'])
     end

--- a/test/lib/store_test.rb
+++ b/test/lib/store_test.rb
@@ -111,5 +111,49 @@ module Wovnrb
 
       assert_equal({'ja' => 'staging-ja', 'en' => 'staging-en'}, s.settings['custom_lang_aliases'])
     end
+
+    def test_dev_mode_on
+      s = Wovnrb::Store.instance
+      s.settings({'dev_mode' => true})
+
+      assert(s.settings['dev_mode'])
+      assert(s.dev_mode?)
+    end
+
+    def test_dev_mode_off_by_default
+      s = Wovnrb::Store.instance
+      s.settings({})
+
+      assert(!s.settings['dev_mode'])
+      assert(!s.dev_mode?)
+    end
+
+    def test_default_api_url_with_dev_mode_on
+      s = Wovnrb::Store.instance
+      s.settings({'dev_mode' => true})
+
+      assert_equal('http://api.dev-wovn.io:3000/v0/values', s.settings['api_url'])
+    end
+
+    def test_default_api_url_with_dev_mode_off
+      s = Wovnrb::Store.instance
+      s.settings({'dev_mode' => false})
+
+      assert_equal('https://api.wovn.io/v0/values', s.settings['api_url'])
+    end
+
+    def test_custom_api_url_not_changed_with_dev_mode_on
+      s = Wovnrb::Store.instance
+      s.settings({'api_url' => 'test-api.io', 'dev_mode' => true})
+
+      assert_equal('test-api.io', s.settings['api_url'])
+    end
+
+    def test_custom_api_url_not_changed_with_dev_mode_off
+      s = Wovnrb::Store.instance
+      s.settings({'api_url' => 'test-api.io', 'dev_mode' => false})
+
+      assert_equal('test-api.io', s.settings['api_url'])
+    end
   end
 end


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Add wovn dev mode setting to enable development with wovn.io local dev server for api and widget access.

### Comments
In wovnrb config, add `'wovn_dev_mode' => true`.
By setting `wovn_dev_mode` to true, wovnrb will use local dev server at `dev-wovn.io:3000` to access page values and widget.
