### PR TITLE
	Add wovnrb.target_lang env to be used in user application

### DIFF
--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -39,7 +39,7 @@ module Wovnrb
       else
         @host = @env['HTTP_HOST']
       end
-      @env['Wovn-Target-Lang'] = self.lang_code
+      @env['WOVN_TARGET_LANG'] = self.lang_code
       @host = settings['url_pattern'] == 'subdomain' ? remove_lang(@host, self.lang_code) : @host
       @pathname, @query = @env['REQUEST_URI'].split('?')
       @pathname = settings['url_pattern'] == 'path' ? remove_lang(@pathname, self.lang_code) : @pathname

--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -39,6 +39,7 @@ module Wovnrb
       else
         @host = @env['HTTP_HOST']
       end
+      @env['Wovn-Target-Lang'] = self.lang_code
       @host = settings['url_pattern'] == 'subdomain' ? remove_lang(@host, self.lang_code) : @host
       @pathname, @query = @env['REQUEST_URI'].split('?')
       @pathname = settings['url_pattern'] == 'path' ? remove_lang(@pathname, self.lang_code) : @pathname

--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -39,7 +39,7 @@ module Wovnrb
       else
         @host = @env['HTTP_HOST']
       end
-      @env['WOVN_TARGET_LANG'] = self.lang_code
+      @env['wovnrb.target_lang'] = self.lang_code
       @host = settings['url_pattern'] == 'subdomain' ? remove_lang(@host, self.lang_code) : @host
       @pathname, @query = @env['REQUEST_URI'].split('?')
       @pathname = settings['url_pattern'] == 'path' ? remove_lang(@pathname, self.lang_code) : @pathname

--- a/test/lib/headers_test.rb
+++ b/test/lib/headers_test.rb
@@ -142,7 +142,7 @@ module Wovnrb
         ),
       )
       env = h.request_out('ja')
-      assert_equal('ja', env['Wovn-Target-Lang'])
+      assert_equal('ja', env['WOVN_TARGET_LANG'])
     end
 
     def test_request_out_with_wovn_target_lang_header_using_path
@@ -151,7 +151,7 @@ module Wovnrb
         Wovnrb.get_settings,
       )
       env = h.request_out('ja')
-      assert_equal('ja', env['Wovn-Target-Lang'])
+      assert_equal('ja', env['WOVN_TARGET_LANG'])
     end
 
     def test_request_out_with_wovn_target_lang_header_using_query
@@ -163,7 +163,7 @@ module Wovnrb
         ),
       )
       env = h.request_out('ja')
-      assert_equal('ja', env['Wovn-Target-Lang'])
+      assert_equal('ja', env['WOVN_TARGET_LANG'])
     end
 
     def test_request_out_with_use_proxy_false
@@ -258,7 +258,7 @@ module Wovnrb
         ),
       )
       headers = h.out(h.request_out('ja'))
-      assert_equal('ja', headers['Wovn-Target-Lang'])
+      assert_equal('ja', headers['WOVN_TARGET_LANG'])
     end
 
     def test_out_with_wovn_target_lang_header_using_path
@@ -267,7 +267,7 @@ module Wovnrb
         Wovnrb.get_settings,
       )
       headers = h.out(h.request_out('ja'))
-      assert_equal('ja', headers['Wovn-Target-Lang'])
+      assert_equal('ja', headers['WOVN_TARGET_LANG'])
     end
 
     def test_out_with_wovn_target_lang_header_using_query
@@ -279,7 +279,7 @@ module Wovnrb
         ),
       )
       headers = h.out(h.request_out('ja'))
-      assert_equal('ja', headers['Wovn-Target-Lang'])
+      assert_equal('ja', headers['WOVN_TARGET_LANG'])
     end
 
     #########################

--- a/test/lib/headers_test.rb
+++ b/test/lib/headers_test.rb
@@ -129,6 +129,43 @@ module Wovnrb
     # REQUEST_OUT
     #########################
 
+    def test_request_out_with_wovn_target_lang_header_with_subdomain
+      h = Wovnrb::Headers.new(
+        Wovnrb.get_env(
+          'SERVER_NAME' => 'ja.wovn.io',
+          'REQUEST_URI' => '/test',
+          'HTTP_REFERER' => 'http://ja.wovn.io/test',
+        ),
+        Wovnrb.get_settings(
+          'url_pattern' => 'subdomain',
+          'url_pattern_reg' => '^(?<lang>[^.]+).',
+        ),
+      )
+      env = h.request_out('ja')
+      assert_equal('ja', env['Wovn-Target-Lang'])
+    end
+
+    def test_request_out_with_wovn_target_lang_header_with_path
+      h = Wovnrb::Headers.new(
+        Wovnrb.get_env('REQUEST_URI' => '/ja/test', 'HTTP_REFERER' => 'http://wovn.io/ja/test'),
+        Wovnrb.get_settings,
+      )
+      env = h.request_out('ja')
+      assert_equal('ja', env['Wovn-Target-Lang'])
+    end
+
+    def test_request_out_with_wovn_target_lang_header_with_query
+      h = Wovnrb::Headers.new(
+        Wovnrb.get_env('REQUEST_URI' => 'test?wovn=ja', 'HTTP_REFERER' => 'http://wovn.io/test'),
+        Wovnrb.get_settings(
+          'url_pattern' => 'query',
+          'url_pattern_reg' => "((\\?.*&)|\\?)wovn=(?<lang>[^&]+)(&|$)",
+        ),
+      )
+      env = h.request_out('ja')
+      assert_equal('ja', env['Wovn-Target-Lang'])
+    end
+
     def test_request_out_with_use_proxy_false
       h = Wovnrb::Headers.new(
         Wovnrb.get_env('url' => 'http://localhost/contact', 'HTTP_X_FORWARDED_HOST' => 'ja.wovn.io'),

--- a/test/lib/headers_test.rb
+++ b/test/lib/headers_test.rb
@@ -142,7 +142,7 @@ module Wovnrb
         ),
       )
       env = h.request_out('ja')
-      assert_equal('ja', env['WOVN_TARGET_LANG'])
+      assert_equal('ja', env['wovnrb.target_lang'])
     end
 
     def test_request_out_with_wovn_target_lang_header_using_path
@@ -151,7 +151,7 @@ module Wovnrb
         Wovnrb.get_settings,
       )
       env = h.request_out('ja')
-      assert_equal('ja', env['WOVN_TARGET_LANG'])
+      assert_equal('ja', env['wovnrb.target_lang'])
     end
 
     def test_request_out_with_wovn_target_lang_header_using_query
@@ -163,7 +163,7 @@ module Wovnrb
         ),
       )
       env = h.request_out('ja')
-      assert_equal('ja', env['WOVN_TARGET_LANG'])
+      assert_equal('ja', env['wovnrb.target_lang'])
     end
 
     def test_request_out_with_use_proxy_false
@@ -258,7 +258,7 @@ module Wovnrb
         ),
       )
       headers = h.out(h.request_out('ja'))
-      assert_equal('ja', headers['WOVN_TARGET_LANG'])
+      assert_equal('ja', headers['wovnrb.target_lang'])
     end
 
     def test_out_with_wovn_target_lang_header_using_path
@@ -267,7 +267,7 @@ module Wovnrb
         Wovnrb.get_settings,
       )
       headers = h.out(h.request_out('ja'))
-      assert_equal('ja', headers['WOVN_TARGET_LANG'])
+      assert_equal('ja', headers['wovnrb.target_lang'])
     end
 
     def test_out_with_wovn_target_lang_header_using_query
@@ -279,7 +279,7 @@ module Wovnrb
         ),
       )
       headers = h.out(h.request_out('ja'))
-      assert_equal('ja', headers['WOVN_TARGET_LANG'])
+      assert_equal('ja', headers['wovnrb.target_lang'])
     end
 
     #########################

--- a/test/lib/headers_test.rb
+++ b/test/lib/headers_test.rb
@@ -129,7 +129,7 @@ module Wovnrb
     # REQUEST_OUT
     #########################
 
-    def test_request_out_with_wovn_target_lang_header_with_subdomain
+    def test_request_out_with_wovn_target_lang_header_using_subdomain
       h = Wovnrb::Headers.new(
         Wovnrb.get_env(
           'SERVER_NAME' => 'ja.wovn.io',
@@ -145,7 +145,7 @@ module Wovnrb
       assert_equal('ja', env['Wovn-Target-Lang'])
     end
 
-    def test_request_out_with_wovn_target_lang_header_with_path
+    def test_request_out_with_wovn_target_lang_header_using_path
       h = Wovnrb::Headers.new(
         Wovnrb.get_env('REQUEST_URI' => '/ja/test', 'HTTP_REFERER' => 'http://wovn.io/ja/test'),
         Wovnrb.get_settings,
@@ -154,7 +154,7 @@ module Wovnrb
       assert_equal('ja', env['Wovn-Target-Lang'])
     end
 
-    def test_request_out_with_wovn_target_lang_header_with_query
+    def test_request_out_with_wovn_target_lang_header_using_query
       h = Wovnrb::Headers.new(
         Wovnrb.get_env('REQUEST_URI' => 'test?wovn=ja', 'HTTP_REFERER' => 'http://wovn.io/test'),
         Wovnrb.get_settings(
@@ -243,6 +243,43 @@ module Wovnrb
       assert_equal('http://wovn.io/test', headers['HTTP_REFERER'])
       headers['Location'] = headers['HTTP_REFERER']
       assert_equal('http://staging-ja.wovn.io/test', h.out(headers)['Location'])
+    end
+
+    def test_out_with_wovn_target_lang_header_using_subdomain
+      h = Wovnrb::Headers.new(
+        Wovnrb.get_env(
+          'SERVER_NAME' => 'ja.wovn.io',
+          'REQUEST_URI' => '/test',
+          'HTTP_REFERER' => 'http://ja.wovn.io/test',
+        ),
+        Wovnrb.get_settings(
+          'url_pattern' => 'subdomain',
+          'url_pattern_reg' => '^(?<lang>[^.]+).',
+        ),
+      )
+      headers = h.out(h.request_out('ja'))
+      assert_equal('ja', headers['Wovn-Target-Lang'])
+    end
+
+    def test_out_with_wovn_target_lang_header_using_path
+      h = Wovnrb::Headers.new(
+        Wovnrb.get_env('REQUEST_URI' => '/ja/test', 'HTTP_REFERER' => 'http://wovn.io/ja/test'),
+        Wovnrb.get_settings,
+      )
+      headers = h.out(h.request_out('ja'))
+      assert_equal('ja', headers['Wovn-Target-Lang'])
+    end
+
+    def test_out_with_wovn_target_lang_header_using_query
+      h = Wovnrb::Headers.new(
+        Wovnrb.get_env('REQUEST_URI' => 'test?wovn=ja', 'HTTP_REFERER' => 'http://wovn.io/test'),
+        Wovnrb.get_settings(
+          'url_pattern' => 'query',
+          'url_pattern_reg' => "((\\?.*&)|\\?)wovn=(?<lang>[^&]+)(&|$)",
+        ),
+      )
+      headers = h.out(h.request_out('ja'))
+      assert_equal('ja', headers['Wovn-Target-Lang'])
     end
 
     #########################


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Add a request env value to make visible the language detected by WovnRB: `wovnrb.target_lang`.

### Comments
Some users want to know the target language detected by WovnRB. This is now possible by looking at the `wovnrb.target_lang` value in the request environment that WovnRB sends to the application (`request.env['wovnrb.target_lang']`).