### PR TITLE
do not add language code to location header when target language is same as default language

### DIFF
--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -210,20 +210,20 @@ module Wovnrb
     def out(headers)
       r = Regexp.new("//" + @host)
       lang_code = Store.instance.settings['custom_lang_aliases'][self.lang_code] || self.lang_code
-      if headers.has_key?("Location") && headers["Location"] =~ r
+      if lang_code != @settings['default_lang'] && headers.has_key?("Location") && headers["Location"] =~ r
         case @settings['url_pattern']
         when 'query'
-          if headers["Location"] =~ /\?/
-            headers["Location"] += "&"
+          if headers['Location'] =~ /\?/
+            headers['Location'] += "&"
           else
-            headers["Location"] += "?"
+            headers['Location'] += "?"
           end
           headers['Location'] += "wovn=#{lang_code}"
         when 'subdomain'
-          headers["Location"] = headers["Location"].sub(/\/\/([^.]+)/, '//' + lang_code + '.\1')
+          headers['Location'] = headers["Location"].sub(/\/\/([^.]+)/, '//' + lang_code + '.\1')
        #when 'path'
         else
-          headers["Location"] = headers['Location'].sub(/(\/\/[^\/]+)/, '\1/' + lang_code)
+          headers['Location'] = headers['Location'].sub(/(\/\/[^\/]+)/, '\1/' + lang_code)
         end
       end
       headers

--- a/test/lib/headers_test.rb
+++ b/test/lib/headers_test.rb
@@ -245,6 +245,60 @@ module Wovnrb
       assert_equal('http://staging-ja.wovn.io/test', h.out(headers)['Location'])
     end
 
+    def test_out_original_lang_with_subdomain_url_pattern
+      h = Wovnrb::Headers.new(
+        Wovnrb.get_env(
+          'SERVER_NAME' => 'wovn.io',
+          'REQUEST_URI' => '/test',
+          'HTTP_REFERER' => 'http://wovn.io/test',
+        ),
+        Wovnrb.get_settings(
+          'url_pattern' => 'subdomain',
+          'url_pattern_reg' => '^(?<lang>[^.]+).',
+        ),
+      )
+      headers = h.request_out(h.lang_code)
+      assert_equal('http://wovn.io/test', headers['HTTP_REFERER'])
+      headers['Location'] = headers['HTTP_REFERER']
+      assert_equal('http://wovn.io/test', h.out(headers)['Location'])
+    end
+
+    def test_out_original_lang_with_path_url_pattern
+      h = Wovnrb::Headers.new(
+        Wovnrb.get_env(
+          'SERVER_NAME' => 'wovn.io',
+          'REQUEST_URI' => '/test',
+          'HTTP_REFERER' => 'http://wovn.io/test',
+        ),
+        Wovnrb.get_settings(
+          'url_pattern' => 'path',
+          'url_pattern_reg' => '/(?<lang>[^/.?]+)',
+        ),
+      )
+      headers = h.request_out(h.lang_code)
+      assert_equal('http://wovn.io/test', headers['HTTP_REFERER'])
+      headers['Location'] = headers['HTTP_REFERER']
+      assert_equal('http://wovn.io/test', h.out(headers)['Location'])
+    end
+
+    def test_out_original_lang_with_query_url_pattern
+      h = Wovnrb::Headers.new(
+        Wovnrb.get_env(
+          'SERVER_NAME' => 'wovn.io',
+          'REQUEST_URI' => '/test',
+          'HTTP_REFERER' => 'http://wovn.io/test',
+        ),
+        Wovnrb.get_settings(
+          'url_pattern' => 'query',
+          'url_pattern_reg' => '((\\?.*&)|\\?)wovn=(?<lang>[^&]+)(&|$)',
+        ),
+      )
+      headers = h.request_out(h.lang_code)
+      assert_equal('http://wovn.io/test', headers['HTTP_REFERER'])
+      headers['Location'] = headers['HTTP_REFERER']
+      assert_equal('http://wovn.io/test', h.out(headers)['Location'])
+    end
+
     def test_out_with_wovn_target_lang_header_using_subdomain
       h = Wovnrb::Headers.new(
         Wovnrb.get_env(


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Do not add lang code in Location header if default language is selected.

### Comments
User needs the fix on 0.2.07 version so I replicated this fix at branch hotfix/0.2.07_default_lang_out_location and I will make a specific tag for them to use.