### PR TITLE
remove restrictions on activesupport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in wovn.gemspec
-if RUBY_VERSION < "2.2.2"
-  spec.add_dependency "activesupport", '< 5.0.0'
+if RUBY_VERSION < '2.2.2'
+  gem 'activesupport', '< 5.0.0'
 end
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in wovn.gemspec
+if RUBY_VERSION < "2.2.2"
+  spec.add_dependency "activesupport", '< 5.0.0'
+end
 gemspec

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -27,11 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "nokogumbo", ">= 1.3.0"
   spec.add_dependency "nokogiri", "<= 1.8"
-  if RUBY_VERSION < "2.2.2"
-    spec.add_dependency "activesupport", '< 5.0.0'
-  else
-    spec.add_dependency "activesupport"
-  end
+  spec.add_dependency "activesupport"
   spec.add_dependency "lz4-ruby"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -27,11 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "nokogumbo", ">= 1.3.0"
   spec.add_dependency "nokogiri", "<= 1.8"
-  if RUBY_VERSION >= "2.2.2"
-    spec.add_dependency "activesupport"
-  else
-    spec.add_dependency "activesupport", '< 5.0.0'
-  end
+  spec.add_dependency "activesupport"
   spec.add_dependency "lz4-ruby"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -27,7 +27,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "nokogumbo", ">= 1.3.0"
   spec.add_dependency "nokogiri", "<= 1.8"
-  spec.add_dependency "activesupport"
+  if RUBY_VERSION >= "2.2.2"
+    spec.add_dependency "activesupport"
+  else
+    spec.add_dependency "activesupport", '< 5.0.0'
+  end
   spec.add_dependency "lz4-ruby"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Avoid activesupport restriction problem.

### Comments
Current restriction does not seem to work and users using ruby version greater than 2.2.2 can't install active support higher than 5.0.0. I think it is fine to remove restriction and let bundle do its job when calculating dependencies (after all wovnrb is not restricted to activesupport lesser than 5.0.0).