### PR TITLE
closure support for config

### DIFF
--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -10,8 +10,15 @@ module Wovnrb
   class Store
     include Singleton
 
+    class SettingsHash < Hash
+      def [](key)
+        value = super
+        value.is_a?(Proc) ? value.call : value
+      end
+    end
+
     def self.default_settings
-      {
+      SettingsHash[
         'project_token' => '',
         'log_path' => 'log/wovn_error.log',
         'ignore_paths' => [],
@@ -30,7 +37,7 @@ module Wovnrb
         'use_proxy' => false,  # use env['HTTP_X_FORWARDED_HOST'] instead of env['HTTP_HOST'] and env['SERVER_NAME'] when this setting is true.
         'custom_lang_aliases' => {},
         'wovn_dev_mode' => false
-      }
+      ]
     end
 
     def initialize


### PR DESCRIPTION
### 目的

複数のサイトを扱うRailsアプリケーションにおいて、サイトごとにプロジェクトトークンを設定できるようにする。
（または設定しないサイトもあり）

### 変更内容

config.wovnrbの設定値にprocオブジェクトを使えるようにしました。

```
config.wovnrb = {
  project_token: lambda { AppConfig[:wovn_project_token] },
  // .....
}
```

のようにすることで、webnrbがproject_tokenの設定値を参照する度に動的に解釈されるようにしました。
（この例のAppConfigはrequestに応じて動的に適切なプロジェクトトークンを返却する想定）

### 問題点

この修正だけだと動作が不安定な状況です。

`ttl_seconds: 0` を入れないと、カスタムの訳語が出力されずにデフォルトの機械翻訳になるなど不安定。
入れた場合でも、404が返ってきたり、wovnのjsが埋め込まれない場合があるなど、不安定。
