### PR TITLE
Ignore AMP content.

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -116,7 +116,7 @@ module Wovnrb
     def is_amp_page?(body)
       html_attributes = body.xpath('//html')[0].try(:attributes) || {}
 
-      !html_attributes['amp'].nil? || !html_attributes["\u26A1"].nil?
+      html_attributes['amp'] || html_attributes["\u26A1"]
     end
   end
 end

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -88,7 +88,8 @@ module Wovnrb
         # If this page has wovn-ignore in the html tag, don't do anything
         if ignore_all || !d.xpath('//html[@wovn-ignore]').empty? || is_amp_page?(d)
           ignore_all = true
-          new_body.push(b)
+          output = d.to_html.gsub(/href="([^"]*)"/) { |m| "href=\"#{URI.decode($1)}\""}
+          new_body.push(output)
           next
         end
 

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -86,10 +86,9 @@ module Wovnrb
         d.encoding = "UTF-8"
 
         # If this page has wovn-ignore in the html tag, don't do anything
-        if ignore_all || !d.xpath('//html[@wovn-ignore]').empty?
+        if ignore_all || !d.xpath('//html[@wovn-ignore]').empty? || is_amp_page?(d)
           ignore_all = true
-          output = d.to_html.gsub(/href="([^"]*)"/) { |m| "href=\"#{URI.decode($1)}\"" }
-          new_body.push(output)
+          new_body.push(b)
           next
         end
 
@@ -104,7 +103,21 @@ module Wovnrb
       body.close if body.respond_to?(:close)
       new_body
     end
-  end
 
+    private
+
+    # Checks if a given HTML body is an Accelerated Mobile Page (AMP).
+    # To do so, it looks at the required attributes for the HTML tag:
+    # https://www.ampproject.org/docs/tutorials/create/basic_markup.
+    #
+    # @param {Nokogiri::HTML5::Document} body The HTML body to check.
+    #
+    # @returns {Boolean} True is the HTML body is an AMP, false otherwise.
+    def is_amp_page?(body)
+      html_attributes = body.xpath('//html')[0].try(:attributes) || {}
+
+      !html_attributes['amp'].nil? || !html_attributes["\u26A1"].nil?
+    end
+  end
 end
 

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -88,7 +88,7 @@ module Wovnrb
         # If this page has wovn-ignore in the html tag, don't do anything
         if ignore_all || !d.xpath('//html[@wovn-ignore]').empty? || is_amp_page?(d)
           ignore_all = true
-          output = d.to_html.gsub(/href="([^"]*)"/) { |m| "href=\"#{URI.decode($1)}\""}
+          output = d.to_html.gsub(/href="([^"]*)"/) { |m| "href=\"#{URI.decode($1)}\"" }
           new_body.push(output)
           next
         end

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -75,6 +75,32 @@ class WovnrbTest < Minitest::Test
     assert_equal([expected_body], swapped_body)
   end
 
+  def test_switch_lang_ignores_amp
+    interceptor = Wovnrb::Interceptor.new(get_app)
+    headers = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
+    body =  "<html amp><body><h1>Mr. Belvedere Fan Club</h1>
+                <div><p>Hello</p></div>
+              </body></html>"
+    values = generate_values
+    url = headers.url
+    swapped_bodies = interceptor.switch_lang([body], values, url, 'ja', headers)
+
+    assert_equal([body], swapped_bodies)
+  end
+
+  def test_switch_lang_ignores_amp_defined_with_symbol_attribute
+    interceptor = Wovnrb::Interceptor.new(get_app)
+    headers = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
+    body =  "<html ⚡><body><h1>Mr. Belvedere Fan Club</h1>
+                <div><p>Hello</p></div>
+              </body></html>"
+    values = generate_values
+    url = headers.url
+    swapped_bodies = interceptor.switch_lang([body], values, url, 'ja', headers)
+
+    assert_equal([body], swapped_bodies)
+  end
+
   def test_switch_lang_with_noscript_in_head
     i = Wovnrb::Interceptor.new(get_app)
     h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -78,27 +78,59 @@ class WovnrbTest < Minitest::Test
   def test_switch_lang_ignores_amp
     interceptor = Wovnrb::Interceptor.new(get_app)
     headers = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
-    body =  "<html amp><body><h1>Mr. Belvedere Fan Club</h1>
-                <div><p>Hello</p></div>
-              </body></html>"
+    body = <<HTML
+<html amp>
+<body>
+  <h1>Mr. Belvedere Fan Club</h1>
+  <div><p>Hello</p></div>
+</body>
+</html>
+HTML
+    expected_body = <<HTML
+<html amp="">
+<head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head>
+<body>
+  <h1>Mr. Belvedere Fan Club</h1>
+  <div><p>Hello</p></div>
+
+
+</body>
+</html>
+HTML
     values = generate_values
     url = headers.url
     swapped_bodies = interceptor.switch_lang([body], values, url, 'ja', headers)
 
-    assert_equal([body], swapped_bodies)
+    assert_equal([expected_body], swapped_bodies)
   end
 
   def test_switch_lang_ignores_amp_defined_with_symbol_attribute
     interceptor = Wovnrb::Interceptor.new(get_app)
     headers = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
-    body =  "<html ⚡><body><h1>Mr. Belvedere Fan Club</h1>
-                <div><p>Hello</p></div>
-              </body></html>"
+    body = <<HTML
+<html ⚡>
+<body>
+  <h1>Mr. Belvedere Fan Club</h1>
+  <div><p>Hello</p></div>
+</body>
+</html>
+HTML
+    expected_body = <<HTML
+<html ⚡="">
+<head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head>
+<body>
+  <h1>Mr. Belvedere Fan Club</h1>
+  <div><p>Hello</p></div>
+
+
+</body>
+</html>
+HTML
     values = generate_values
     url = headers.url
     swapped_bodies = interceptor.switch_lang([body], values, url, 'ja', headers)
 
-    assert_equal([body], swapped_bodies)
+    assert_equal([expected_body], swapped_bodies)
   end
 
   def test_switch_lang_with_noscript_in_head


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Do nothing for AMP content

### Comments
WOVN widget does not support AMP content, so we should ignore those pages. If we don't ignore them the pages could be added on WOVN.io (e.g. if page is directly open in browser for testing). AMP content can be detected by looking at the HTML tag (https://www.ampproject.org/docs/tutorials/create/basic_markup).