### PR TITLE
Add the ability for users to support different tokens for different requests

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -50,8 +50,8 @@ module Wovnrb
         unless @store.settings['ignore_globs'].any?{|g| g.match?(headers.pathname)}
           # If the user defines a token for this request, use it instead of the config token
           request = Rack::Request.new(env)
-          if @store.valid_token?(request['wovn_token'])
-            @store.settings['project_token'] = request['wovn_token']
+          if @store.valid_token?(request.params['wovn_token'])
+            @store.settings['project_token'] = request.params['wovn_token']
           end
           # ApiData creates request for external server, but cannot use async.
           # Because some server not allow multi thread. (env['async.callback'] is not supported at all Server).

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -1,3 +1,4 @@
+require 'rack'
 require 'wovnrb/store'
 require 'wovnrb/headers'
 require 'wovnrb/lang'
@@ -47,6 +48,11 @@ module Wovnrb
 
       if res_headers["Content-Type"] =~ /html/
         unless @store.settings['ignore_globs'].any?{|g| g.match?(headers.pathname)}
+          # If the user defines a token for this request, use it instead of the config token
+          request = Rack::Request.new(env)
+          if @store.valid_token?(request['wovn_token'])
+            @store.settings['project_token'] = request['wovn_token']
+          end
           # ApiData creates request for external server, but cannot use async.
           # Because some server not allow multi thread. (env['async.callback'] is not supported at all Server).
           api_data = ApiData.new(headers.redis_url, @store)

--- a/lib/wovnrb/api_data.rb
+++ b/lib/wovnrb/api_data.rb
@@ -31,7 +31,7 @@ module Wovnrb
 
     @@cache_prefix = 'api::cache::'
     def to_key(url)
-      "#{@@cache_prefix}#{url}"
+      "::" + @store.settings['project_token'] + "::#{@@cache_prefix}#{url}"
     end
 
     def build_api_uri

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -48,13 +48,21 @@ module Wovnrb
       @config_loaded = false
     end
 
+    # Returns true or false based on whether the token is valid or not
+    #
+    # @return [Boolean] Returns true if the token is valid, and false if it is not
+    def valid_token?(token)
+      return !token.nil? && (token.length == 5 || token.length == 6)
+    end
+
     # Returns true or false based on whether the settings are valid or not, logs any invalid settings to ../error.log
     #
     # @return [Boolean] Returns true if the settings are valid, and false if they are not
     def valid_settings?
       valid = true
       errors = [];
-      if !settings.has_key?('project_token') || settings['project_token'].length < 5 || settings['project_token'].length > 6
+      #if valid_token?(!settings.has_key?('project_token') || settings['project_token'].length < 5 || settings['project_token'].length > 6
+      if !valid_token?(settings['project_token'])
         valid = false
         errors.push("Project token #{settings['project_token']} is not valid.")
       end

--- a/test/lib/api_data_test.rb
+++ b/test/lib/api_data_test.rb
@@ -25,7 +25,7 @@ module Wovnrb
       stub_request(:get, "https://api.wovn.io/v0/values?token=#{token}&url=#{url}").
         to_return(:body => '{"test_body": "a"}')
       store = Wovnrb::Store.instance
-      store.settings('user_token' => token)
+      store.settings('project_token' => token)
       api_data = Wovnrb::ApiData.new(url, store)
 
       assert_equal({'test_body' => 'a'}, api_data.get_data)
@@ -37,12 +37,33 @@ module Wovnrb
       stub = stub_request(:get, "https://api.wovn.io/v0/values?token=#{token}&url=#{url}").
         to_return(:body => '{"test_body": "a"}')
       store = Wovnrb::Store.instance
-      store.settings('user_token' => token)
+      store.settings('project_token' => token)
       api_data = Wovnrb::ApiData.new(url, store)
 
       assert_equal({'test_body' => 'a'}, api_data.get_data)
       assert_equal({'test_body' => 'a'}, api_data.get_data)
       assert_requested(stub, :times => 1)
+    end
+
+    def test_get_data_cache_with_different_project_tokens
+      token = 'a'
+      url = 'url'
+      stub_a = stub_request(:get, "https://api.wovn.io/v0/values?token=#{token}&url=#{url}").
+        to_return(:body => '{"test_body": "a"}')
+      store = Wovnrb::Store.instance
+      api_data = Wovnrb::ApiData.new(url, store)
+
+      store.settings('project_token' => token)
+      assert_equal({'test_body' => 'a'}, api_data.get_data)
+
+      token = 'b'
+      stub_b = stub_request(:get, "https://api.wovn.io/v0/values?token=#{token}&url=#{url}").
+        to_return(:body => '{"test_body": "a"}')
+      store.settings('project_token' => token)
+      assert_equal({'test_body' => 'a'}, api_data.get_data)
+
+      assert_requested(stub_a, :times => 1)
+      assert_requested(stub_b, :times => 1)
     end
 
     def test_get_data_fail
@@ -51,7 +72,7 @@ module Wovnrb
       stub_request(:get, "https://api.wovn.io/v0/values?token=#{token}&url=#{url}").
         to_return(:status => [500, "Internal Server Error"])
       store = Wovnrb::Store.instance
-      store.settings('user_token' => token)
+      store.settings('project_token' => token)
       api_data = Wovnrb::ApiData.new(url, store)
       log_mock = Wovnrb::LogMock.mock_log
 

--- a/test/lib/store_test.rb
+++ b/test/lib/store_test.rb
@@ -104,6 +104,42 @@ module Wovnrb
       assert_equal([], s.settings['ignore_globs'])
     end
 
+    def test_valid_user_token
+      mock = LogMock.mock_log
+      store = Wovnrb::Store.instance
+
+      assert_equal(true, store.valid_token?('12345'))
+    end
+
+    def test_valid_project_token
+      mock = LogMock.mock_log
+      store = Wovnrb::Store.instance
+
+      assert_equal(true, store.valid_token?('123456'))
+    end
+
+    def test_invalid_token_nil
+      mock = LogMock.mock_log
+      store = Wovnrb::Store.instance
+      settings = {'not_a_token' => '12345'}
+
+      assert_equal(false, store.valid_token?(settings['token']))
+    end
+
+    def test_invalid_token_too_short
+      mock = LogMock.mock_log
+      store = Wovnrb::Store.instance
+
+      assert_equal(false, store.valid_token?('hi'))
+    end
+
+    def test_invalid_token_too_long
+      mock = LogMock.mock_log
+      store = Wovnrb::Store.instance
+
+      assert_equal(false, store.valid_token?('1234567'))
+    end
+
     def test_add_custom_lang_aliases_empty
       s = Wovnrb::Store.instance
       s.settings({'custom_lang_aliases' => {}})

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -44,7 +44,7 @@ class WovnrbTest < Minitest::Test
     stub = stub_request(:get, "#{settings['api_url']}?token=#{token}&url=#{url}").
       to_return(:body => '{"test_body": "a"}')
 
-    i = Wovnrb::Interceptor.new(RackMock.new, settings)
+    i = Wovnrb::Interceptor.new(get_app, settings)
 
     i.call(Wovnrb.get_env)
     i.call(Wovnrb.get_env)
@@ -59,10 +59,24 @@ class WovnrbTest < Minitest::Test
     stub = stub_request(:get, "#{settings['api_url']}?token=#{request_token}&url=#{url}").
       to_return(:body => '{"test_body": "a"}')
 
-    i = Wovnrb::Interceptor.new(RackMock.new, settings)
+    i = Wovnrb::Interceptor.new(get_app(:params => {'wovn_token' => request_token}), settings)
 
     env = Wovnrb.get_env
-    env['wovn_token'] = request_token
+    i.call(env)
+    assert_requested(stub, :times => 1)
+  end
+
+  def test_request_invalid_wovn_token
+    settings = Wovnrb.get_settings
+    settings['project_token'] = 'token0'
+    request_token = 'invalidtoken1'
+    url = 'wovn.io/dashboard'
+    stub = stub_request(:get, "#{settings['api_url']}?token=#{settings['project_token']}&url=#{url}").
+      to_return(:body => '{"test_body": "a"}')
+
+    i = Wovnrb::Interceptor.new(get_app(:params => {'wovn_token' => settings['project_token']}), settings)
+
+    env = Wovnrb.get_env
     i.call(env)
     assert_requested(stub, :times => 1)
   end
@@ -291,8 +305,8 @@ HTML
     assert_equal([expected_body], swapped_body)
   end
 
-  def get_app
-    RackMock.new
+  def get_app(opts={})
+    RackMock.new(opts)
   end
 
   def generate_values
@@ -303,8 +317,29 @@ HTML
   end
 
   class RackMock
+    def initialize(opts={})
+      @params = {}
+      if opts.has_key?(:params) && opts[:params].class == Hash
+        opts[:params].each do |key, val|
+          @params[key] = val
+        end
+      end
+      @request_headers = {}
+    end
+
     def call(env)
+      @env = env
+      if @params.length > 0
+        req = Rack::Request.new(@env)
+        @params.each do |key, val|
+          req.update_param(key, val)
+        end
+      end
       [200, {'Content-Type' => 'text/html'}, ['']]
+    end
+
+    def [](key)
+      @env[key]
     end
   end
 end

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -3,6 +3,7 @@ require 'wovnrb'
 require 'wovnrb/headers'
 require 'minitest/autorun'
 require 'webmock/minitest'
+require 'rack'
 require 'pry'
 
 class WovnrbTest < Minitest::Test
@@ -47,6 +48,22 @@ class WovnrbTest < Minitest::Test
 
     i.call(Wovnrb.get_env)
     i.call(Wovnrb.get_env)
+    assert_requested(stub, :times => 1)
+  end
+
+  def test_request_wovn_token
+    settings = Wovnrb.get_settings
+    settings['project_token'] = 'token0'
+    request_token = 'token1'
+    url = 'wovn.io/dashboard'
+    stub = stub_request(:get, "#{settings['api_url']}?token=#{request_token}&url=#{url}").
+      to_return(:body => '{"test_body": "a"}')
+
+    i = Wovnrb::Interceptor.new(RackMock.new, settings)
+
+    env = Wovnrb.get_env
+    env['wovn_token'] = request_token
+    i.call(env)
     assert_requested(stub, :times => 1)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -73,12 +73,12 @@ module Wovnrb
     env['SERVER_NAME'] = 'wovn.io'
     env['HTTP_COOKIE'] = "olfsk=olfsk021093478426337242; hblid=KB8AAMzxzu2DSxnB4X7BJ26rBGVeF0yJ; optimizelyEndUserId=oeu1426233718869r0.5398541854228824; __zlcmid=UFeZqrVo6Mv3Yl; wovn_selected_lang=en; optimizelySegments=%7B%7D; optimizelyBuckets=%7B%7D; _equalizer_session=eDFwM3M2QUZJZFhoby9JZlArckcvSUJwNFRINXhUeUxtNnltQXZhV0tqdGhZQjJMZ01URnZTK05ydFVWYmM3U0dtMVN0M0Z0UnNDVG8vdUNDTUtPc21jY0FHREgrZ05CUnBTb0hyUlkvYlBWQVhQR3RZdnhjMWsrRW5rOVp1Z3V3bkgyd3NpSlRZQWU1dlZvNmM1THp6aUZVeE83Y1pWWENRNTBUVFIrV05WeTdDMlFlem1tUzdxaEtndFZBd2dtUjU2ak5EUmJPa3RWWmMyT1pSVWdMTm8zOVZhUWhHdGQ3L1c5bm91RmNSdFRrcC90Tml4N2t3ZWlBaDRya2lLT1I0S0J2TURhUWl6Uk5rOTQ4Y1MwM3VKYnlLMUYraEt5clhRdFd1eGdEWXdZd3pFbWQvdE9vQndhdDVQbXNLcHBURm9CbnZKenU2YnNXRFdqRVl0MVV3bmRyYjhvMDExcGtUVU9tK1lqUGswM3p6M05tbVRnTjE3TUl5cEdpTTZ4a2gray8xK0FvTC9wUDVka1JSeE5GM1prZmRjWDdyVzRhWW5uS2Mxc1BxOEVVTTZFS3N5bTlVN2p5eE5YSjNZWGI2UHd3Vzc0bDM5QjIwL0l5Mm85NmQyWFAwdVQ3ZzJYYk1QOHY2NVJpY2c9LS1KNU96eHVycVJxSDJMbEc4Rm9KVXpBPT0%3D--17e47555d692fb9cde20ef78a09a5eabbf805bb3; mp_a0452663eb7abb7dfa9c94007ebb0090_mixpanel=%7B%22distinct_id%22%3A%20%2253ed9ffa4a65662e37000000%22%2C%22%24initial_referrer%22%3A%20%22http%3A%2F%2Fp.dev-wovn.io%3A8080%2Fhttp%3A%2F%2Fdev-wovn.io%3A3000%22%2C%22%24initial_referring_domain%22%3A%20%22p.dev-wovn.io%3A8080%22%2C%22__mps%22%3A%20%7B%7D%2C%22__mpso%22%3A%20%7B%7D%2C%22__mpa%22%3A%20%7B%7D%2C%22__mpu%22%3A%20%7B%7D%2C%22__mpap%22%3A%20%5B%5D%7D"
     env['HTTP_ACCEPT_LANGUAGE'] = 'ja,en-US;q=0.8,en;q=0.6'
-    env['QUERY_STRING'] = 'param=val&hey=you'
     env['ORIGINAL_FULLPATH'] = '/dashboard?param=val&hey=you'
     #env['HTTP_REFERER'] =
     env['REQUEST_PATH'] = '/dashboard'
     env['PATH_INFO'] = '/dashboard'
 
+    url = options['url'] || "http://wovn.io/dashboard?param=val&hey=you"
     if options['url']
       url = URI.parse(options['url'])
       env['rack.url_scheme'] = url.scheme
@@ -93,7 +93,8 @@ module Wovnrb
       env['REQUEST_PATH'] = url.path
       env['PATH_INFO'] = url.path
     end
-    return env.merge(options)
+
+    return Rack::MockRequest.env_for(url, env.merge(options))
   end
 
   def to_dom(html)

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "lz4-ruby"
 
+  spec.add_dependency "rack", "~>1.5.2"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "listen", "~> 3.0.6"


### PR DESCRIPTION
The user can modify the Rack::Request object to change the token on a per-request basis
```
Rack::Request.new(env).update_param('wovn_token', 'test1')
```

I will add and fix the tests!!

### Purpose/goal of Pull Request (Issue #)
This is for cloud CMS services who want to be able to load a token per user based on which website they are serving.

### Comments
