### PR TITLE
Keep original encoding and decoding for href

### DIFF
--- a/test/lib/lang_test.rb
+++ b/test/lib/lang_test.rb
@@ -583,5 +583,27 @@ module Wovnrb
       h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://favy.tips'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
       assert_equal("http://staging-fr.favy.tips/topics/50", lang.add_lang_code("/topics/50", 'subdomain', h))
     end
+
+    def test_switch_dom_lang_for_keeping_originl_encoding_decoding
+      lang = Lang.new('ja')
+      header = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings)
+      html = <<-HTML
+        <ul>
+          <li><a href="http://page.com/%e5%ba%83%e5%b0%be">encoded japanese path</a></li>
+          <li><a href="http://page.com/テスト/DxA9J">no encoded japanese path</a></li>
+          <li><a href="http://page.com/#DnE897">decoded invalid path</a></li>
+          <li><a href="http://page.com/%23DnE897">encoded invalid path</a>
+        </ul>
+      HTML
+
+      dom = Wovnrb.to_dom(html)
+      url = header.url
+
+      swapped_body = lang.switch_dom_lang(dom, Store.instance, generate_values, url, header)
+      assert(swapped_body.include?('<a href="http://page.com/ja/%e5%ba%83%e5%b0%be">encoded japanese path</a>'))
+      assert(swapped_body.include?('<a href="http://page.com/ja/テスト/DxA9J">no encoded japanese path</a>'))
+      assert(swapped_body.include?('<a href="http://page.com/ja/#DnE897">decoded invalid path</a>'))
+      assert(swapped_body.include?('<a href="http://page.com/ja/%23DnE897">encoded invalid path</a>'))
+    end
   end
 end


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
issues link https://github.com/WOVNio/equalizer/issues/7361

currently when user use encoded url as href, wovn.rb return decoded url as the href.

ex: 
when user use this encoded japanese path.
```
<a href="http://ccc.com:4300/%E3%83%86%E3%82%B9%E3%83%88/DxA9J">this is encoded japanese path</a></li>
```

we return decoded url with wovnrb
```
<a href="http://ccc.com:4300/テスト/DxA9J">this is encoded japanese path</a>
```


we should keep original encoding and decoding for href as much as possible.

### Comments

this probrem come from nokogiri. nokogiri encode href automatically when we use `#to_html` to dom object made from nokogiri. so we had decoded all href.  so when we use encoded href, we return decoded href like below flow.

1. we specify encoded url as href.
1. nokogiri encode this url, but this url already was encoded. so it don't any change.
1. we decode all href. so this url is decoded. but original url is encoded url. it's probrem.