### PR TITLE
Feature Proposal: Add wovn_disable parameter

### DIFF
--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = "0.2.29"
+  VERSION = "0.2.30"
 end

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -81,6 +81,20 @@ class WovnrbTest < Minitest::Test
     assert_requested(stub, :times => 1)
   end
 
+  def test_request_wovn_disable
+    settings = Wovnrb.get_settings
+    token = settings['project_token']
+    url = 'wovn.io/dashboard'
+    stub = stub_request(:get, "#{settings['api_url']}?token=#{token}&url=#{url}").
+      to_return(:body => '{"test_body": "a"}')
+
+    i = Wovnrb::Interceptor.new(get_app(:params => {'wovn_disable' => true}), settings)
+
+    env = Wovnrb.get_env
+    i.call(env)
+    assert_requested(stub, :times => 0)
+  end
+
   def test_switch_lang
     i = Wovnrb::Interceptor.new(get_app)
     h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))


### PR DESCRIPTION
Sometimes users need to set the project token dynamically. We supported this with wovn_token which allows the user to set the token on a per-request basis.

In the same way, sometimes users don't want WOVNrb to make any API call (or do any HTML transformations). To support this, I've added the wovn_disable parameter. If the user sets the parameter to true:
`Rack::Request.new(env).update_param('wovn_disable', true) `
Then WOVNrb will not make an API call and will not modify the HTML. (It will still mask the headers)

The reason I think we should support this is because it will reduce the number of unnecessary requests to our API, and it will increase the speed of WOVNrb when the user wants to disable it.

### Purpose/goal of Pull Request (Issue #)

### Comments
Please tell me if you can think of any more test cases or if you want me to stop using the API call stub. I will modify the test cases.