### PR TITLE
Hotfix/dynamic token 500 server error

### DIFF
--- a/lib/wovnrb/lang.rb
+++ b/lib/wovnrb/lang.rb
@@ -1,4 +1,7 @@
 # -*- encoding: UTF-8 -*-
+
+require 'addressable'
+
 module Wovnrb
   class Lang
     LANG = {

--- a/lib/wovnrb/lang.rb
+++ b/lib/wovnrb/lang.rb
@@ -180,8 +180,12 @@ module Wovnrb
       result = {}
       dom.xpath('//*[@href]').each do |a_tag|
         url = a_tag['href']
-        encoded_url = Addressable::URI.parse(url).normalize.to_s
-        result[encoded_url] = url if encoded_url != url
+        begin
+          encoded_url = Addressable::URI.parse(url).normalize.to_s
+          result[encoded_url] = url if encoded_url != url
+        rescue Addressable::URI::InvalidURIError => e
+          WovnLogger.instance.error("Failed parse url : #{url}#{e.message}")
+        end
       end
       result
     end

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -161,7 +161,7 @@ module Wovnrb
       end
 
       if @settings.has_key?('custom_lang_aliases')
-        @settings['custom_lang_aliases'].stringify_keys!
+        stringify_keys! @settings['custom_lang_aliases']
       end
 
       if wovn_dev_mode? && @settings['api_url'] == Store.default_settings['api_url']
@@ -188,6 +188,11 @@ module Wovnrb
     def cleanSettings
       @settings['ignore_globs'] = []
     end
-  end
 
+    def stringify_keys!(h)
+      h.keys.each do |k|
+        h[k.to_s] = h.delete(k)
+      end
+    end
+  end
 end

--- a/test/lib/lang_test.rb
+++ b/test/lib/lang_test.rb
@@ -611,5 +611,15 @@ module Wovnrb
       assert(swapped_body.include?('<a href="http://page.com/ja/#DnE897">decoded invalid path</a>'))
       assert(swapped_body.include?('<a href="http://page.com/ja/%23DnE897">encoded invalid path</a>'))
     end
+
+    def test_switch_dom_lang_with_invalid_link
+      lang = Lang.new('en')
+      header = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings)
+      html = '<a href="※ http://invalid.example.com">無効なリンク</a>'
+      dom = Wovnrb.to_dom(html)
+      url = header.url
+      swapped_body = lang.switch_dom_lang(dom, Store.instance, generate_values, url, header)
+      assert(swapped_body.include?('html'))
+    end
   end
 end

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "lz4-ruby"
   spec.add_dependency "rack"
+  spec.add_dependency "addressable"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #7823)
Related: https://github.com/WOVNio/equalizer/issues/7823

The fix is to occur Internal Server Error on some page that page has invalid href '※http://...'.
And removed functions that depend on Rails about `stringify_keys!` and `const_missing`.

The branch name include dynamic token but does not relate it, sorry.


### Comments

This is stack trace on customer server.
```
E, [2018-01-25T00:15:17.052738 #2025] ERROR -- : app error: Invalid scheme format: ※http (Addressable::URI::InvalidURIError)
E, [2018-01-25T00:15:17.052958 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/addressable-2.5.2/lib/addressable/uri.rb:874:in `scheme='
E, [2018-01-25T00:15:17.052998 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/addressable-2.5.2/lib/addressable/uri.rb:799:in `block in initialize'
E, [2018-01-25T00:15:17.053028 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/addressable-2.5.2/lib/addressable/uri.rb:2355:in `defer_validation'
E, [2018-01-25T00:15:17.053055 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/addressable-2.5.2/lib/addressable/uri.rb:796:in `initialize'
E, [2018-01-25T00:15:17.053083 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/addressable-2.5.2/lib/addressable/uri.rb:136:in `new'
E, [2018-01-25T00:15:17.053110 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/addressable-2.5.2/lib/addressable/uri.rb:136:in `parse'
E, [2018-01-25T00:15:17.053137 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/wovnrb-0.2.30/lib/wovnrb/lang.rb:180:in `block in index_href_for_encoding_and_decoding'
E, [2018-01-25T00:15:17.053165 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/nokogiri-1.8.0/lib/nokogiri/xml/node_set.rb:190:in `block in each'
E, [2018-01-25T00:15:17.053191 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/nokogiri-1.8.0/lib/nokogiri/xml/node_set.rb:189:in `upto'
E, [2018-01-25T00:15:17.053218 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/nokogiri-1.8.0/lib/nokogiri/xml/node_set.rb:189:in `each'
E, [2018-01-25T00:15:17.053280 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/wovnrb-0.2.30/lib/wovnrb/lang.rb:178:in `index_href_for_encoding_and_decoding'
E, [2018-01-25T00:15:17.053312 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/wovnrb-0.2.30/lib/wovnrb/lang.rb:167:in `switch_dom_lang'
E, [2018-01-25T00:15:17.053340 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/wovnrb-0.2.30/lib/wovnrb.rb:107:in `block in switch_lang'
E, [2018-01-25T00:15:17.053368 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/body_proxy.rb:36:in `block in each'
E, [2018-01-25T00:15:17.053396 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/body_proxy.rb:36:in `block in each'
E, [2018-01-25T00:15:17.053424 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_dispatch/http/response.rb:145:in `each'
E, [2018-01-25T00:15:17.053451 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_dispatch/http/response.rb:145:in `each_chunk'
E, [2018-01-25T00:15:17.053478 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_dispatch/http/response.rb:126:in `each'
E, [2018-01-25T00:15:17.053505 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_dispatch/http/response.rb:74:in `each'
E, [2018-01-25T00:15:17.053532 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_dispatch/http/response.rb:473:in `each'
E, [2018-01-25T00:15:17.053559 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/body_proxy.rb:36:in `each'
E, [2018-01-25T00:15:17.053586 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/body_proxy.rb:36:in `each'
E, [2018-01-25T00:15:17.053613 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/wovnrb-0.2.30/lib/wovnrb.rb:86:in `switch_lang'
E, [2018-01-25T00:15:17.053640 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/wovnrb-0.2.30/lib/wovnrb.rb:67:in `call'
E, [2018-01-25T00:15:17.053667 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/newrelic_rpm-4.7.1.340/lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
E, [2018-01-25T00:15:17.053694 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/railties-5.1.4/lib/rails/engine.rb:522:in `call'
E, [2018-01-25T00:15:17.053776 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/newrelic_rpm-4.7.1.340/lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
E, [2018-01-25T00:15:17.053807 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/unicorn-5.4.0/lib/unicorn/http_server.rb:606:in `process_client'
E, [2018-01-25T00:15:17.053835 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/unicorn-worker-killer-0.4.4/lib/unicorn/worker_killer.rb:52:in `process_client'
E, [2018-01-25T00:15:17.053862 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/unicorn-worker-killer-0.4.4/lib/unicorn/worker_killer.rb:92:in `process_client'
E, [2018-01-25T00:15:17.053889 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/unicorn-5.4.0/lib/unicorn/http_server.rb:701:in `worker_loop'
E, [2018-01-25T00:15:17.053931 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/unicorn-5.4.0/lib/unicorn/http_server.rb:549:in `spawn_missing_workers'
E, [2018-01-25T00:15:17.053962 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/unicorn-5.4.0/lib/unicorn/http_server.rb:142:in `start'
E, [2018-01-25T00:15:17.053990 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/gems/unicorn-5.4.0/bin/unicorn:126:in `<top (required)>'
E, [2018-01-25T00:15:17.054082 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/bin/unicorn:23:in `load'
E, [2018-01-25T00:15:17.054113 #2025] ERROR -- : /var/www/clipkit/demo-tenant/production/shared/vendor/bundle/ruby/2.4.0/bin/unicorn:23:in `<top (required)>'
E, [2018-01-25T00:15:17.054141 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `load'
E, [2018-01-25T00:15:17.054169 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `kernel_load'
E, [2018-01-25T00:15:17.054196 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:28:in `run'
E, [2018-01-25T00:15:17.054224 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli.rb:424:in `exec'
E, [2018-01-25T00:15:17.054251 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
E, [2018-01-25T00:15:17.054278 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
E, [2018-01-25T00:15:17.054306 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
E, [2018-01-25T00:15:17.054333 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli.rb:27:in `dispatch'
E, [2018-01-25T00:15:17.054360 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
E, [2018-01-25T00:15:17.054387 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli.rb:18:in `start'
E, [2018-01-25T00:15:17.054415 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/exe/bundle:30:in `block in <top (required)>'
E, [2018-01-25T00:15:17.054442 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/friendly_errors.rb:122:in `with_friendly_errors'
E, [2018-01-25T00:15:17.054469 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/exe/bundle:22:in `<top (required)>'
E, [2018-01-25T00:15:17.054496 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/bin/bundle:23:in `load'
E, [2018-01-25T00:15:17.054523 #2025] ERROR -- : /usr/local/rbenv/versions/2.4.3/bin/bundle:23:in `<main>'
```
