### PR TITLE
Add the ability for users to support different ignore_paths settings for different requests

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -51,7 +51,7 @@ module Wovnrb
 
         request = Rack::Request.new(env)
         unless request.params['wovn_disable'] == true
-          @store.settings.update_dynamic!(request.params)
+          @store.settings.update_dynamic_settings!(request.params)
           unless @store.settings['ignore_globs'].any?{|g| g.match?(headers.pathname)}
 
             # ApiData creates request for external server, but cannot use async.

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -28,7 +28,7 @@ module Wovnrb
     end
 
     def call(env)
-      @store.settings.clear_dynamic!
+      @store.settings.clear_dynamic_settings!
       unless Store.instance.valid_settings?
         return @app.call(env)
       end

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -28,6 +28,7 @@ module Wovnrb
     end
 
     def call(env)
+      @store.settings.clear_dynamic!
       unless Store.instance.valid_settings?
         return @app.call(env)
       end
@@ -50,11 +51,9 @@ module Wovnrb
 
         request = Rack::Request.new(env)
         unless request.params['wovn_disable'] == true
+          @store.settings.update_dynamic!(request.params)
           unless @store.settings['ignore_globs'].any?{|g| g.match?(headers.pathname)}
-            # If the user defines a token for this request, use it instead of the config token
-            if @store.valid_token?(request.params['wovn_token'])
-              @store.settings['project_token'] = request.params['wovn_token']
-            end
+
             # ApiData creates request for external server, but cannot use async.
             # Because some server not allow multi thread. (env['async.callback'] is not supported at all Server).
             api_data = ApiData.new(headers.redis_url, @store)
@@ -135,4 +134,3 @@ module Wovnrb
     end
   end
 end
-

--- a/lib/wovnrb/settings.rb
+++ b/lib/wovnrb/settings.rb
@@ -1,0 +1,37 @@
+module Wovnrb
+  class Settings < Hash
+    def initialize(*args, **kwargs)
+      super(*args, **kwargs)
+      @dynamic_settings = {}
+    end
+
+    def [](key)
+      return @dynamic_settings[key] if @dynamic_settings.key?(key)
+      return ignore_globs if key == 'ignore_globs'
+      super(key)
+    end
+
+    def ignore_globs
+      ignore_paths = self['ignore_paths']
+      return [] unless ignore_paths.kind_of?(Array)
+      ignore_paths.map { |pattern| Glob.new(pattern) }
+    end
+
+    def clear_dynamic_settings!
+      @dynamic_settings.clear
+    end
+
+    def update_dynamic!(params)
+      # If the user defines dynamic settings for this request, use it instead of the config
+      DYNAMIC_KEYS.each do |params_key, setting_key|
+        value = params[params_key]
+        @dynamic_settings[setting_key] = value if value
+      end
+    end
+
+    DYNAMIC_KEYS = {
+      'wovn_token' => 'project_token',
+      'wovn_ignore_paths' => 'ignore_paths',
+    }
+  end
+end

--- a/lib/wovnrb/settings.rb
+++ b/lib/wovnrb/settings.rb
@@ -21,7 +21,7 @@ module Wovnrb
       @dynamic_settings.clear
     end
 
-    def update_dynamic!(params)
+    def update_dynamic_settings!(params)
       # If the user defines dynamic settings for this request, use it instead of the config
       DYNAMIC_KEYS.each do |params_key, setting_key|
         value = params[params_key]

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -4,6 +4,7 @@ require 'cgi'
 require 'singleton'
 require 'wovnrb/services/wovn_logger'
 require 'wovnrb/services/glob'
+require 'wovnrb/settings'
 require 'active_support'
 
 module Wovnrb
@@ -184,41 +185,5 @@ module Wovnrb
         h[k.to_s] = h.delete(k)
       end
     end
-  end
-
-  class Settings < Hash
-    def initialize(*args, **kwargs)
-      super(*args, **kwargs)
-      @dynamic = {}
-    end
-
-    def [](key)
-      return @dynamic[key] if @dynamic.key?(key)
-      return ignore_globs if key == 'ignore_globs'
-      super(key)
-    end
-
-    def ignore_globs
-      ignore_paths = self['ignore_paths']
-      return [] unless ignore_paths.kind_of?(Array)
-      ignore_paths.map { |pattern| Glob.new(pattern) }
-    end
-
-    def clear_dynamic!
-      @dynamic.clear
-    end
-
-    def update_dynamic!(params)
-      # If the user defines dynamic settings for this request, use it instead of the config
-      DYNAMIC.each do |params_key, setting_key|
-        value = params[params_key]
-        @dynamic[setting_key] = value if value
-      end
-    end
-
-    DYNAMIC = {
-      'wovn_token' => 'project_token',
-      'wovn_ignore_paths' => 'ignore_paths',
-    }
   end
 end


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Relate: https://github.com/WOVNio/wovnrb/pull/94

The user can modify the Rack::Request object to change the token on a per-request basis.
This is example for sinatra. Also other rack application can do it by simuler way.
```
require 'sinatra/base'

class Server < Sinatra::Base
  get '/dynamic_ignore' do
    request.update_param('wovn_ignore_paths', ['/dynamic_ignore', '/other_rule'])
    erb :index
  end 
end
```

### Comments
`wovn_token` and this one can be used together.