### PR TITLE
Implement support for HTTP_X_FORWARDED_PROTO or other proxy's header.

### DIFF
--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -14,9 +14,11 @@ module Wovnrb
     # Its parameters are set by parsing env variable.
     #
     def initialize(env, settings)
+      request = Rack::Request.new(env)
+
       @env = env
       @settings = settings
-      @protocol = @env['rack.url_scheme']
+      @protocol = request.scheme
       if settings['use_proxy'] && @env.has_key?('HTTP_X_FORWARDED_HOST')
         @unmasked_host = @env['HTTP_X_FORWARDED_HOST']
       else

--- a/test/lib/headers_test.rb
+++ b/test/lib/headers_test.rb
@@ -104,6 +104,12 @@ module Wovnrb
       assert_equal('wovn.io/dashboard', h.redis_url)
     end
 
+    def test_initialize_with_proto_header
+      env = Wovnrb.get_env('url' => 'http://page.com', 'HTTP_X_FORWARDED_PROTO' => 'https')
+      h = Wovnrb::Headers.new(env, Wovnrb.get_settings('query' => ['aaa']))
+      assert_equal('https', h.protocol)
+    end
+
     #########################
     # REDIRECT_LOCATION
     #########################

--- a/test/lib/lang_test.rb
+++ b/test/lib/lang_test.rb
@@ -480,6 +480,18 @@ module Wovnrb
       assert(!(/html lang="zh-CHT"/ =~ swapped_body))
     end
 
+    def test_switch_dom_lang_when_proxy_change_protocol
+      lang = Lang.new('en')
+      env = Wovnrb.get_env('url' => 'http://page.com', 'HTTP_X_FORWARDED_PROTO' => 'https')
+      header = Wovnrb::Headers.new(env, Wovnrb.get_settings)
+      html = '<html></html>'
+      dom = Wovnrb.to_dom(html)
+      url = header.url
+      swapped_body = lang.switch_dom_lang(dom, Store.instance, generate_values, url, header)
+      assert(swapped_body.include?('hreflang="ja" href="https://page.com/ja/"'))
+      assert(swapped_body.include?('hreflang="en" href="https://page.com/"'))
+    end
+
     def test_switch_lang
       lang = Lang.new('ja')
       h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,10 +14,12 @@ SimpleCov.start do
 end
 
 require 'nokogumbo'
+require 'rack'
 require 'wovnrb/headers'
 require 'wovnrb/lang'
 require 'wovnrb/store'
 require 'wovnrb/html_replacers/replacer_base'
+require 'wovnrb/html_replacers/input_replacer'
 require 'wovnrb/html_replacers/link_replacer'
 require 'wovnrb/html_replacers/text_replacer'
 require 'wovnrb/html_replacers/meta_replacer'


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Implement support for HTTP_X_FORWARDED_PROTO or other proxy's header.

### Comments
When there is some special headers, use the protocol instead of rack's request url.
You can check headers at https://github.com/rack/rack/blob/master/lib/rack/request.rb#L188.