### PR TITLE
prevent replacing any link that is javascript code

### DIFF
--- a/lib/wovnrb/html_replacers/link_replacer.rb
+++ b/lib/wovnrb/html_replacers/link_replacer.rb
@@ -18,7 +18,7 @@ module Wovnrb
 
         href = node.get_attribute('href')
         next if href =~ /^\s*\{\{.+\}\}\s*$/
-        next if href =~ /^\s*javascript:/
+        next if href =~ /^\s*javascript:/i
         next if is_file?(href)
         new_href = lang.add_lang_code(href, @pattern, @headers)
         node.set_attribute('href', new_href)

--- a/lib/wovnrb/html_replacers/link_replacer.rb
+++ b/lib/wovnrb/html_replacers/link_replacer.rb
@@ -18,7 +18,7 @@ module Wovnrb
 
         href = node.get_attribute('href')
         next if href =~ /^\s*\{\{.+\}\}\s*$/
-        next if href =~ /javascript:void\(/
+        next if href =~ /^\s*javascript:/
         next if is_file?(href)
         new_href = lang.add_lang_code(href, @pattern, @headers)
         node.set_attribute('href', new_href)

--- a/test/lib/html_replacers/link_replacer_test.rb
+++ b/test/lib/html_replacers/link_replacer_test.rb
@@ -51,6 +51,15 @@ module Wovnrb
       assert_equal('javascript:onclick($(\'.any\').slideToggle());', link)
     end
 
+    def test_replace_upercased_javascript_code_link_query
+      replacer = LinkReplacer.new('query', get_header)
+      dom = Wovnrb.get_dom('<a href="JAVASCRIPT:onclick($(\'.any\').slideToggle());">link text</a>')
+      replacer.replace(dom, Lang.new('en'))
+
+      link = dom.xpath('//a')[0].get_attribute('href')
+      assert_equal('JAVASCRIPT:onclick($(\'.any\').slideToggle());', link)
+    end
+
     def test_replace_empty_javascript_link_path
       replacer = LinkReplacer.new('path', get_header)
       dom = Wovnrb.get_dom('<a href="javascript:void(0);">link text</a>')
@@ -67,6 +76,15 @@ module Wovnrb
 
       link = dom.xpath('//a')[0].get_attribute('href')
       assert_equal('javascript:onclick($(\'.any\').slideToggle());', link)
+    end
+
+    def test_replace_upercased_javascript_code_link_path
+      replacer = LinkReplacer.new('path', get_header)
+      dom = Wovnrb.get_dom('<a href="JAVASCRIPT:onclick($(\'.any\').slideToggle());">link text</a>')
+      replacer.replace(dom, Lang.new('en'))
+
+      link = dom.xpath('//a')[0].get_attribute('href')
+      assert_equal('JAVASCRIPT:onclick($(\'.any\').slideToggle());', link)
     end
 
     def test_replace_link_path

--- a/test/lib/html_replacers/link_replacer_test.rb
+++ b/test/lib/html_replacers/link_replacer_test.rb
@@ -33,7 +33,7 @@ module Wovnrb
       assert_equal('/index.html', link)
     end
 
-    def test_replace_javascript_link_query
+    def test_replace_empty_javascript_link_query
       replacer = LinkReplacer.new('query', get_header)
       dom = Wovnrb.get_dom('<a href="javascript:void(0);">link text</a>')
       replacer.replace(dom, Lang.new('en'))
@@ -42,13 +42,31 @@ module Wovnrb
       assert_equal('javascript:void(0);', link)
     end
 
-    def test_replace_javascript_link_path
+    def test_replace_javascript_code_link_query
+      replacer = LinkReplacer.new('query', get_header)
+      dom = Wovnrb.get_dom('<a href="javascript:onclick($(\'.any\').slideToggle());">link text</a>')
+      replacer.replace(dom, Lang.new('en'))
+
+      link = dom.xpath('//a')[0].get_attribute('href')
+      assert_equal('javascript:onclick($(\'.any\').slideToggle());', link)
+    end
+
+    def test_replace_empty_javascript_link_path
       replacer = LinkReplacer.new('path', get_header)
       dom = Wovnrb.get_dom('<a href="javascript:void(0);">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
       link = dom.xpath('//a')[0].get_attribute('href')
       assert_equal('javascript:void(0);', link)
+    end
+
+    def test_replace_javascript_code_link_path
+      replacer = LinkReplacer.new('path', get_header)
+      dom = Wovnrb.get_dom('<a href="javascript:onclick($(\'.any\').slideToggle());">link text</a>')
+      replacer.replace(dom, Lang.new('en'))
+
+      link = dom.xpath('//a')[0].get_attribute('href')
+      assert_equal('javascript:onclick($(\'.any\').slideToggle());', link)
     end
 
     def test_replace_link_path

--- a/test/lib/html_replacers/link_replacer_test.rb
+++ b/test/lib/html_replacers/link_replacer_test.rb
@@ -51,7 +51,7 @@ module Wovnrb
       assert_equal('javascript:onclick($(\'.any\').slideToggle());', link)
     end
 
-    def test_replace_upercased_javascript_code_link_query
+    def test_replace_uppercased_javascript_code_link_query
       replacer = LinkReplacer.new('query', get_header)
       dom = Wovnrb.get_dom('<a href="JAVASCRIPT:onclick($(\'.any\').slideToggle());">link text</a>')
       replacer.replace(dom, Lang.new('en'))
@@ -78,7 +78,7 @@ module Wovnrb
       assert_equal('javascript:onclick($(\'.any\').slideToggle());', link)
     end
 
-    def test_replace_upercased_javascript_code_link_path
+    def test_replace_uppercased_javascript_code_link_path
       replacer = LinkReplacer.new('path', get_header)
       dom = Wovnrb.get_dom('<a href="JAVASCRIPT:onclick($(\'.any\').slideToggle());">link text</a>')
       replacer.replace(dom, Lang.new('en'))


### PR DESCRIPTION
### Purpose/goal of Pull Request
Prevent replacing any link that is javascript code

### Comments
Only the case of `href="javascript:void(0);"` was handle, but any javascript code should be handled.
