### PR TITLE
Include widget snippet also for when values are zero.

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -67,10 +67,6 @@ module Wovnrb
       api_data = ApiData.new(headers.redis_url, @store)
       values = api_data.get_data
 
-      unless have_data?(values)
-        return output(headers, status, res_headers, body)
-      end
-
       url = {
         :protocol => headers.protocol,
         :host => headers.host,
@@ -113,8 +109,8 @@ module Wovnrb
         if have_data?(values)
           output = lang.switch_dom_lang(d, @store, values, url, headers)
         else
-          script_replacer = ScriptReplacer.new(@store)
-          output = script_replacer.replace(d, lang)
+          ScriptReplacer.new(@store).replace(d, lang)
+          output = d.to_html
         end
         put_back_noscripts!(output, noscripts)
         new_body.push(output)

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -110,7 +110,12 @@ module Wovnrb
           next
         end
 
-        output = lang.switch_dom_lang(d, @store, values, url, headers)
+        if have_data?(values)
+          output = lang.switch_dom_lang(d, @store, values, url, headers)
+        else
+          scriptReplacer = ScriptReplacer.new(@store)
+          ouput = scriptReplacer.replace(d, lang)
+        end
         put_back_noscripts!(output, noscripts)
         new_body.push(output)
       end

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -113,8 +113,8 @@ module Wovnrb
         if have_data?(values)
           output = lang.switch_dom_lang(d, @store, values, url, headers)
         else
-          scriptReplacer = ScriptReplacer.new(@store)
-          ouput = scriptReplacer.replace(d, lang)
+          script_replacer = ScriptReplacer.new(@store)
+          output = script_replacer.replace(d, lang)
         end
         put_back_noscripts!(output, noscripts)
         new_body.push(output)


### PR DESCRIPTION
### Purpose/goal of Pull Request
For issue https://github.com/WOVNio/equalizer/issues/10957

Make sure to always include widget, even if no values are found for the page.

### Comments

I'm not 100% sure that this will solve the problem at Shushugirl (some pages don't get automatically added), but I believe that this behavior is correct for wovnrb regardless.