### PR TITLE
No extra new line when outputting html

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -105,7 +105,7 @@ module Wovnrb
         # If this page has wovn-ignore in the html tag, don't do anything
         if ignore_all || !d.xpath('//html[@wovn-ignore]').empty? || is_amp_page?(d)
           ignore_all = true
-          output = d.to_html.gsub(/href="([^"]*)"/) { |m| "href=\"#{URI.decode($1)}\"" }
+          output = d.to_html(save_with: 0).gsub(/href="([^"]*)"/) { |m| "href=\"#{URI.decode($1)}\"" }
           put_back_noscripts!(output, noscripts)
           new_body.push(output)
           next
@@ -115,7 +115,7 @@ module Wovnrb
           output = lang.switch_dom_lang(d, @store, values, url, headers)
         else
           ScriptReplacer.new(@store).replace(d, lang)
-          output = d.to_html
+          output = d.to_html(save_with: 0)
         end
         put_back_noscripts!(output, noscripts)
         new_body.push(output)

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -182,16 +182,9 @@ class WovnrbTest < Minitest::Test
     url = h.url
     swapped_body = i.switch_lang([body], values, url, 'ja', h)
 
-    expected_body = "<html>
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script>
-</head>
-<body>
-<h1>Mr. Belvedere Fan Club</h1>
+    expected_body = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script></head><body><h1>Mr. Belvedere Fan Club</h1>
                 <div><p>Hello</p></div>
-              </body>
-</html>
+              </body></html>
 "
     assert_equal([expected_body], swapped_body)
   end
@@ -209,18 +202,13 @@ class WovnrbTest < Minitest::Test
 </html>
 HTML
     expected_body = <<HTML
-<html amp="">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-</head>
+<html amp=""><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript></head>
 <body>
   <h1>Mr. Belvedere Fan Club</h1>
   <div><p>Hello</p></div>
 
 
-</body>
-</html>
+</body></html>
 HTML
     values = generate_values
     url = headers.url
@@ -241,15 +229,12 @@ HTML
 </html>
 HTML
     expected_body = <<HTML
-<html ⚡="">
-<head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head>
-<body>
+<html ⚡=""><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>
   <h1>Mr. Belvedere Fan Club</h1>
   <div><p>Hello</p></div>
 
 
-</body>
-</html>
+</body></html>
 HTML
     values = generate_values
     url = headers.url


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Adds fix to prevent Nokogiri from adding extra new lines that could break the page html for some frameworks (ex: Nuxt)
### Comments
