### PR TITLE
Handle HTML Fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ After completing setup, start the Ruby Application, and make sure the WOVN.io li
 
 WOVN.io Ruby Library's valid parameters are as follows.
 
-Parameter Name      | Required | Default Setting
-------------------- | -------- | ----------------
-project_token       | yes      | ''
-url_pattern         | yes      | 'path'
-query               |          | []
-default_lang        | yes      | 'en'
-ignore_class        |          | []
-translate_fragments |          | true
+Parameter Name     | Required | Default Setting
+------------------ | -------- | ----------------
+project_token      | yes      | ''
+url_pattern        | yes      | 'path'
+query              |          | []
+default_lang       | yes      | 'en'
+ignore_class       |          | []
+translate_fragment |          | true
 
 ### 2.1. project_token
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This sets "Ignore class" which prevent WOVN translating HTML elements that have 
 
 This option allows to disable translating partial HTML content. By default,
 partial HTML content is translated but no widget snippet is added. Set
-"translate_fragment" to 'false' to stop translatinf partial HTML content.
+"translate_fragment" to 'false' to stop translating partial HTML content.
 
 ## 3. Contributing
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ After completing setup, start the Ruby Application, and make sure the WOVN.io li
 
 WOVN.io Ruby Library's valid parameters are as follows.
 
-Parameter Name | Required | Default Setting
--------------- | -------- | ----------------
-project_token  | yes      | ''
-url_pattern    | yes      | 'path'
-query          |          | []
-default_lang   | yes      | 'en'
-ignore_class   |          | []
+Parameter Name      | Required | Default Setting
+------------------- | -------- | ----------------
+project_token       | yes      | ''
+url_pattern         | yes      | 'path'
+query               |          | []
+default_lang        | yes      | 'en'
+ignore_class        |          | []
+translate_fragments |          | true
 
 ### 2.1. project_token
 
@@ -123,6 +124,12 @@ The library will redirect to the following URL.
 ### 2.5 ignore_class
 
 This sets "Ignore class" which prevent WOVN translating HTML elements that have one of the array.
+
+### 2.6 translate_fragment
+
+This option allows to disable translating partial HTML content. By default,
+partial HTML content is translated but no widget snippet is added. Set
+"translate_fragment" to 'false' to stop translatinf partial HTML content.
 
 ## 3. Contributing
 

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -5,6 +5,7 @@ require 'wovnrb/lang'
 require 'nokogumbo'
 #require 'dom'
 require 'json'
+require 'wovnrb/helpers/nokogumbo_helper'
 require 'wovnrb/api_data'
 require 'wovnrb/text_caches/cache_base'
 require 'wovnrb/html_replacers/replacer_base'
@@ -99,8 +100,8 @@ module Wovnrb
           noscripts << match
           b_without_noscripts = b_without_noscripts.sub(match, noscript_identifier)
         end
-        d = Nokogiri::HTML5(b_without_noscripts)
-        d.encoding = "UTF-8"
+
+        d = Helpers::NokogumboHelper::parse_html(b_without_noscripts)
 
         # If this page has wovn-ignore in the html tag, don't do anything
         if ignore_all || !d.xpath('//html[@wovn-ignore]').empty? || is_amp_page?(d)
@@ -114,7 +115,7 @@ module Wovnrb
         if have_data?(values)
           output = lang.switch_dom_lang(d, @store, values, url, headers)
         else
-          ScriptReplacer.new(@store).replace(d, lang)
+          ScriptReplacer.new(@store).replace(d, lang) if d.html?
           output = d.to_html(save_with: 0)
         end
         put_back_noscripts!(output, noscripts)

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -112,7 +112,7 @@ module Wovnrb
           next
         end
 
-        if have_data?(values)
+        if should_translate?(d, values)
           output = lang.switch_dom_lang(d, @store, values, url, headers)
         else
           ScriptReplacer.new(@store).replace(d, lang) if d.html?
@@ -130,6 +130,12 @@ module Wovnrb
     def output(headers, status, res_headers, body)
       headers.out(res_headers)
       [status, res_headers, body]
+    end
+
+    def should_translate?(dom, values)
+      translatable_html = dom.html? ? true : @store.settings['translate_fragment']
+
+      translatable_html && have_data?(values)
     end
 
     def have_data?(values)

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -112,7 +112,7 @@ module Wovnrb
           next
         end
 
-        if should_translate?(d, values)
+        if must_translate?(d, values)
           output = lang.switch_dom_lang(d, @store, values, url, headers)
         else
           ScriptReplacer.new(@store).replace(d, lang) if d.html?
@@ -132,10 +132,10 @@ module Wovnrb
       [status, res_headers, body]
     end
 
-    def should_translate?(dom, values)
-      translatable_html = dom.html? ? true : @store.settings['translate_fragment']
+    def must_translate?(dom, values)
+      can_translate = dom.html? ? true : @store.settings['translate_fragment']
 
-      translatable_html && have_data?(values)
+      can_translate && have_data?(values)
     end
 
     def have_data?(values)

--- a/lib/wovnrb/helpers/nokogumbo_helper.rb
+++ b/lib/wovnrb/helpers/nokogumbo_helper.rb
@@ -1,0 +1,61 @@
+module Wovnrb
+  module Helpers
+    module NokogumboHelper
+      def parse_html(html_string, encoding = 'UTF-8')
+        dom = if html_string.strip[0..999] =~ /<html/i
+                d = Nokogiri::HTML5(html_string)
+                d.encoding = encoding
+                d
+              else
+                parse_fragment(html_string, encoding)
+              end
+
+        return dom
+      end
+
+      # https://www.rubydoc.info/gems/nokogumbo/Nokogiri/HTML5#fragment-class_method
+      #
+      # Nokogumbo does not properly support parsing fragment and the current
+      # implementation of Nokogiri::HTML5.fragment does not handle encoding
+      # (second line of code below).
+      def parse_fragment(html_string, encoding = 'UTF-8')
+        doc = Nokogiri::HTML5.parse(html_string)
+        doc.encoding = encoding
+        fragment = Nokogiri::HTML::DocumentFragment.new(doc)
+
+        if doc.children.length != 1 or doc.children.first.name != 'html'
+          # no HTML?  Return document as is
+          fragment = doc
+        else
+          # examine children of HTML element
+          children = doc.children.first.children
+
+          # head is always first.  If present, take children but otherwise
+          # ignore the head element
+          if children.length > 0 and doc.children.first.name = 'head'
+            fragment << children.shift.children
+          end
+
+          # body may be next, or last.  If found, take children but otherwise
+          # ignore the body element.  Also take any remaining elements, taking
+          # care to preserve order.
+          if children.length > 0 and doc.children.first.name = 'body'
+            fragment << children.shift.children
+            fragment << children
+          elsif children.length > 0 and doc.children.last.name = 'body'
+            body = children.pop
+            fragment << children
+            fragment << body.children
+          else
+            fragment << children
+          end
+        end
+
+        # return result
+        fragment
+      end
+
+      module_function :parse_html, :parse_fragment
+    end
+  end
+end

--- a/lib/wovnrb/html_replacers/image_replacer.rb
+++ b/lib/wovnrb/html_replacers/image_replacer.rb
@@ -10,7 +10,7 @@ module Wovnrb
     end
 
     def replace(dom, lang)
-      dom.xpath('//img').each do |node|
+      dom.xpath('.//img').each do |node|
         next if wovn_ignore?(node)
 
         # use regular expressions to support case insensitivity (right?)

--- a/lib/wovnrb/html_replacers/input_replacer.rb
+++ b/lib/wovnrb/html_replacers/input_replacer.rb
@@ -6,7 +6,7 @@ module Wovnrb
     end
 
     def replace(dom, lang)
-      dom.xpath('//input').each do |node|
+      dom.xpath('.//input').each do |node|
         next if wovn_ignore?(node)
 
         set_attribute('value', node, lang)       if replaceable_value? node

--- a/lib/wovnrb/html_replacers/meta_replacer.rb
+++ b/lib/wovnrb/html_replacers/meta_replacer.rb
@@ -8,7 +8,7 @@ module Wovnrb
     end
 
     def replace(dom, lang)
-      dom.xpath('//meta').select { |node|
+      dom.xpath('.//meta').select { |node|
         next if wovn_ignore?(node)
         (node.get_attribute('name') || node.get_attribute('property') || '') =~ /^(description|title|og:title|og:description|og:url|twitter:title|twitter:description)$/
       }.each do |node|

--- a/lib/wovnrb/html_replacers/replacer_base.rb
+++ b/lib/wovnrb/html_replacers/replacer_base.rb
@@ -12,7 +12,7 @@ module Wovnrb
     def wovn_ignore?(node)
       if !node.get_attribute('wovn-ignore').nil?
         return true
-      elsif node.name === 'html'
+      elsif node.name === 'html' || node.parent.nil?
         return false
       end
 

--- a/lib/wovnrb/html_replacers/text_replacer.rb
+++ b/lib/wovnrb/html_replacers/text_replacer.rb
@@ -6,7 +6,7 @@ module Wovnrb
     end
 
     def replace(dom, lang)
-      dom.xpath('//text()').each do |node|
+      dom.xpath('.//text()').each do |node|
         next if wovn_ignore?(node)
 
         node_text = node.content.strip

--- a/lib/wovnrb/lang.rb
+++ b/lib/wovnrb/lang.rb
@@ -215,7 +215,6 @@ module Wovnrb
       end
 
       replacers << TextReplacer.new(store, text_index)
-      # TODO: review xpath on the replacers below
       replacers << MetaReplacer.new(store, text_index, pattern, headers)
       replacers << InputReplacer.new(store, text_index)
       replacers << ImageReplacer.new(store, url, text_index, src_index, img_src_prefix, host_aliases)

--- a/lib/wovnrb/lang.rb
+++ b/lib/wovnrb/lang.rb
@@ -180,7 +180,7 @@ module Wovnrb
       # NOTE: when we use `#to_html` with nokogiri, nokogiri encode all href.
       #       but we want to keep original href as much as possible.
       #       That's why we replace href with original href which added lang info by wovnrb like this after we used `to_html`
-      dom.to_html.gsub(/href="([^"]*)"/) { |m| "href=\"#{index_href[$1] || $1}\"" }
+      dom.to_html(save_with: 0).gsub(/href="([^"]*)"/) { |m| "href=\"#{index_href[$1] || $1}\"" }
     end
 
     private

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -31,7 +31,8 @@ module Wovnrb
         'ttl_seconds' => nil,
         'use_proxy' => false,  # use env['HTTP_X_FORWARDED_HOST'] instead of env['HTTP_HOST'] and env['SERVER_NAME'] when this setting is true.
         'custom_lang_aliases' => {},
-        'wovn_dev_mode' => false
+        'wovn_dev_mode' => false,
+        'translate_fragment' => true
       })
     end
 

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = "1.0.10"
+  VERSION = "1.0.11"
 end

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = "1.0.9"
+  VERSION = "1.0.10"
 end

--- a/test/lib/html_replacers/image_replacer_test.rb
+++ b/test/lib/html_replacers/image_replacer_test.rb
@@ -29,6 +29,31 @@ module Wovnrb
       assert_equal('wovn-src:Hello', img.previous.content)
     end
 
+    def test_replace_in_fragment
+      store = Store.instance
+      url = {
+        :protocol => 'http',
+        :host => 'www.example.com',
+        :pathname => 'hello/index.html'
+      }
+      text_index = {
+        'Hello' => {'ja' => [{'data' => 'こんにちは'}]}
+      }
+      src_index = {
+        'http://www.example.com/test.img' => {'ja' => [{'data' => 'http://test.com/ttt.img'}]}
+      }
+      img_src_prefix = 'prefix::'
+      replacer = ImageReplacer.new(store, url, text_index, src_index, img_src_prefix, [])
+
+      dom = Helpers::NokogumboHelper::parse_fragment('<img src="http://www.example.com/test.img" alt="Hello">')
+      replacer.replace(dom, Lang.new('ja'))
+
+      img = dom.xpath('.//img')[0]
+      assert_equal('prefix::http://test.com/ttt.img', img.get_attribute('src'))
+      assert_equal('こんにちは', img.get_attribute('alt'))
+      assert_equal('wovn-src:Hello', img.previous.content)
+    end
+
     def test_replace_relative_path
       store = Store.instance
       url = {

--- a/test/lib/html_replacers/input_replacer_test.rb
+++ b/test/lib/html_replacers/input_replacer_test.rb
@@ -17,6 +17,19 @@ module Wovnrb
       assert_equal('こんにちは', content)
     end
 
+    def test_replace_in_fragment
+      store = Store.instance
+      replacer = InputReplacer.new(store, {
+        'Hello' => {'ja' => [{'data' => 'こんにちは'}]}
+      })
+
+      dom = Helpers::NokogumboHelper::parse_fragment('<input type="submit" value="Hello">')
+      replacer.replace(dom, Lang.new('ja'))
+
+      content = dom.xpath('.//input')[0].get_attribute('value')
+      assert_equal('こんにちは', content)
+    end
+
     def test_dont_replace_empty_submit_value
       store = Store.instance
       replacer = InputReplacer.new(store, {

--- a/test/lib/html_replacers/meta_replacer_test.rb
+++ b/test/lib/html_replacers/meta_replacer_test.rb
@@ -17,6 +17,19 @@ module Wovnrb
       assert_equal('こんにちは', content)
     end
 
+    def test_replace_description_in_fragment
+      store = Store.instance
+      replacer = MetaReplacer.new(store, {
+        'Hello' => {'ja' => [{'data' => 'こんにちは'}]}
+      })
+
+      dom = Helpers::NokogumboHelper::parse_fragment('<meta name="description" content="Hello">')
+      replacer.replace(dom, Lang.new('ja'))
+
+      content = dom.xpath('.//meta')[0].get_attribute('content')
+      assert_equal('こんにちは', content)
+    end
+
     def test_replace_og_description
       store = Store.instance
       replacer = MetaReplacer.new(store, {
@@ -85,6 +98,22 @@ module Wovnrb
       assert_equal('さようなら', content2)
     end
 
+    def test_replace_multi_in_fragment
+      store = Store.instance
+      replacer = MetaReplacer.new(store, {
+        'Hello' => {'ja' => [{'data' => 'こんにちは'}]},
+        'Bye' => {'ja' => [{'data' => 'さようなら'}]}
+      })
+
+      dom = Helpers::NokogumboHelper::parse_fragment('<meta property="title" content="Hello"><meta property="title" content="Bye">')
+      replacer.replace(dom, Lang.new('ja'))
+
+      content = dom.xpath('.//meta')[0].get_attribute('content')
+      content2 = dom.xpath('.//meta')[1].get_attribute('content')
+      assert_equal('こんにちは', content)
+      assert_equal('さようなら', content2)
+    end
+
     def test_replace_wovn_ignore
       store = Store.instance
       replacer = MetaReplacer.new(store, {
@@ -95,6 +124,19 @@ module Wovnrb
       replacer.replace(dom, Lang.new('ja'))
 
       content = dom.xpath('//meta')[0].get_attribute('content')
+      assert_equal('Hello', content)
+    end
+
+    def test_replace_wovn_ignore_on_fragment
+      store = Store.instance
+      replacer = MetaReplacer.new(store, {
+        'Hello' => {'ja' => [{'data' => 'こんにちは'}]},
+      })
+
+      dom = Helpers::NokogumboHelper::parse_fragment('<meta wovn-ignore property="title" content="Hello">')
+      replacer.replace(dom, Lang.new('ja'))
+
+      content = dom.xpath('.//meta')[0].get_attribute('content')
       assert_equal('Hello', content)
     end
 

--- a/test/lib/html_replacers/replacer_base_test.rb
+++ b/test/lib/html_replacers/replacer_base_test.rb
@@ -17,7 +17,7 @@ module Wovnrb
       store = Store.instance
       replacer = ReplacerBase.new(store)
       dom = Wovnrb.to_dom('<html wovn-ignore><body><div wovn-ignore></div></body></html>')
-      actual = replacer.send(:wovn_ignore?, dom.xpath('//div')[0])
+      actual = replacer.send(:wovn_ignore?, dom.xpath('.//div')[0])
 
       assert(actual)
     end
@@ -58,6 +58,33 @@ HTML
       assert(replacer.send(:wovn_ignore?, dom.xpath('//div')[0]))
       assert(replacer.send(:wovn_ignore?, dom.xpath('//span')[0]))
       assert_equal(false, replacer.send(:wovn_ignore?, dom.xpath('//p')[0]))
+
+    def test_wovn_ignore_fragment
+      store = Store.instance
+      replacer = ReplacerBase.new(store)
+      dom = Nokogiri::HTML5.fragment('<div wovn-ignore></div>')
+      actual = replacer.send(:wovn_ignore?, dom.xpath('.//div')[0])
+
+      assert(actual)
+    end
+    end
+
+    def test_wovn_ignore_fragment_parent
+      store = Store.instance
+      replacer = ReplacerBase.new(store)
+      dom = Nokogiri::HTML5.fragment('<div wovn-ignore><span></span></div>')
+      actual = replacer.send(:wovn_ignore?, dom.xpath('.//span')[0])
+
+      assert(actual)
+    end
+
+    def test_wovn_ignore_fragment_no_wovn_ignore
+      store = Store.instance
+      replacer = ReplacerBase.new(store)
+      dom = Nokogiri::HTML5.fragment('<div><span></span></div>')
+      actual = replacer.send(:wovn_ignore?, dom.xpath('.//span')[0])
+
+      assert(!actual)
     end
 
     def test_replace_text

--- a/test/lib/html_replacers/replacer_base_test.rb
+++ b/test/lib/html_replacers/replacer_base_test.rb
@@ -17,7 +17,7 @@ module Wovnrb
       store = Store.instance
       replacer = ReplacerBase.new(store)
       dom = Wovnrb.to_dom('<html wovn-ignore><body><div wovn-ignore></div></body></html>')
-      actual = replacer.send(:wovn_ignore?, dom.xpath('.//div')[0])
+      actual = replacer.send(:wovn_ignore?, dom.xpath('//div')[0])
 
       assert(actual)
     end
@@ -62,7 +62,7 @@ HTML
     def test_wovn_ignore_fragment
       store = Store.instance
       replacer = ReplacerBase.new(store)
-      dom = Nokogiri::HTML5.fragment('<div wovn-ignore></div>')
+      dom = Helpers::NokogumboHelper.parse_fragment('<div wovn-ignore></div>')
       actual = replacer.send(:wovn_ignore?, dom.xpath('.//div')[0])
 
       assert(actual)
@@ -72,7 +72,7 @@ HTML
     def test_wovn_ignore_fragment_parent
       store = Store.instance
       replacer = ReplacerBase.new(store)
-      dom = Nokogiri::HTML5.fragment('<div wovn-ignore><span></span></div>')
+      dom = Helpers::NokogumboHelper.parse_fragment('<div wovn-ignore><span></span></div>')
       actual = replacer.send(:wovn_ignore?, dom.xpath('.//span')[0])
 
       assert(actual)
@@ -81,7 +81,7 @@ HTML
     def test_wovn_ignore_fragment_no_wovn_ignore
       store = Store.instance
       replacer = ReplacerBase.new(store)
-      dom = Nokogiri::HTML5.fragment('<div><span></span></div>')
+      dom = Helpers::NokogumboHelper.parse_fragment('<div><span></span></div>')
       actual = replacer.send(:wovn_ignore?, dom.xpath('.//span')[0])
 
       assert(!actual)

--- a/test/lib/html_replacers/text_replacer_test.rb
+++ b/test/lib/html_replacers/text_replacer_test.rb
@@ -18,6 +18,20 @@ module Wovnrb
       assert_equal('wovn-src:Hello', node.previous.content)
     end
 
+    def test_replace_in_fragment
+      store = Store.instance
+      replacer = TextReplacer.new(store,{
+        'Hello' => {'ja' => [{'data' => 'こんにちは'}]}
+      })
+
+      dom = Helpers::NokogumboHelper::parse_html('<span>Hello</span>')
+      replacer.replace(dom, Lang.new('ja'))
+
+      node = dom.xpath('.//text()')[0]
+      assert_equal('こんにちは', node.content)
+      assert_equal('wovn-src:Hello', node.previous.content)
+    end
+
     def test_replace_multiple
       store = Store.instance
       replacer = TextReplacer.new(store, {
@@ -36,6 +50,24 @@ module Wovnrb
       assert_equal('wovn-src:Bye', node2.previous.content)
     end
 
+    def test_replace_multiple_in_fragment
+      store = Store.instance
+      replacer = TextReplacer.new(store, {
+        'Hello' => {'ja' => [{'data' => 'こんにちは'}]},
+        'Bye' => {'ja' => [{'data' => 'さようなら'}]}
+      })
+
+      dom = Helpers::NokogumboHelper::parse_html('<span>Hello</span><span>Bye</span>')
+      replacer.replace(dom, Lang.new('ja'))
+
+      node = dom.xpath('.//text()')[0]
+      node2 = dom.xpath('.//text()')[1]
+      assert_equal('こんにちは', node.content)
+      assert_equal('wovn-src:Hello', node.previous.content)
+      assert_equal('さようなら', node2.content)
+      assert_equal('wovn-src:Bye', node2.previous.content)
+    end
+
     def test_replace_wovn_ignore
       store = Store.instance
       replacer = TextReplacer.new(store, {
@@ -46,6 +78,20 @@ module Wovnrb
       replacer.replace(dom, Lang.new('ja'))
 
       node = dom.xpath('//text()')[0]
+      assert_equal('Hello', node.content)
+      assert_nil(node.previous)
+    end
+
+    def test_replace_wovn_ignore_on_fragment
+      store = Store.instance
+      replacer = TextReplacer.new(store, {
+        'Hello' => {'ja' => [{'data' => 'こんにちは'}]}
+      })
+
+      dom = Helpers::NokogumboHelper::parse_html('<div wovn-ignore>Hello</div>')
+      replacer.replace(dom, Lang.new('ja'))
+
+      node = dom.xpath('.//text()')[0]
       assert_equal('Hello', node.content)
       assert_nil(node.previous)
     end

--- a/test/lib/html_replacers/text_replacer_test.rb
+++ b/test/lib/html_replacers/text_replacer_test.rb
@@ -24,7 +24,7 @@ module Wovnrb
         'Hello' => {'ja' => [{'data' => 'こんにちは'}]}
       })
 
-      dom = Helpers::NokogumboHelper::parse_html('<span>Hello</span>')
+      dom = Helpers::NokogumboHelper::parse_fragment('<span>Hello</span>')
       replacer.replace(dom, Lang.new('ja'))
 
       node = dom.xpath('.//text()')[0]
@@ -57,7 +57,7 @@ module Wovnrb
         'Bye' => {'ja' => [{'data' => 'さようなら'}]}
       })
 
-      dom = Helpers::NokogumboHelper::parse_html('<span>Hello</span><span>Bye</span>')
+      dom = Helpers::NokogumboHelper::parse_fragment('<span>Hello</span><span>Bye</span>')
       replacer.replace(dom, Lang.new('ja'))
 
       node = dom.xpath('.//text()')[0]
@@ -88,7 +88,7 @@ module Wovnrb
         'Hello' => {'ja' => [{'data' => 'こんにちは'}]}
       })
 
-      dom = Helpers::NokogumboHelper::parse_html('<div wovn-ignore>Hello</div>')
+      dom = Helpers::NokogumboHelper::parse_fragment('<div wovn-ignore>Hello</div>')
       replacer.replace(dom, Lang.new('ja'))
 
       node = dom.xpath('.//text()')[0]

--- a/test/lib/lang_test.rb
+++ b/test/lib/lang_test.rb
@@ -2,8 +2,6 @@
 require 'test_helper'
 require 'minitest/autorun'
 
-require 'wovnrb/helpers/nokogumbo_helper'
-
 module Wovnrb
   class LangTest < WovnMiniTest
     def test_langs_exist
@@ -470,7 +468,7 @@ module Wovnrb
     def test_switch_lang_with_html_fragment
       lang = Lang.new('ja')
       h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
-      dom = Helpers::NokogumboHelper::parse_html('<span>Hello</span>')
+      dom = Helpers::NokogumboHelper::parse_fragment('<span>Hello</span>')
       values = generate_values
       url = h.url
       swapped_body = lang.switch_dom_lang(dom, Store.instance, values, url, h)

--- a/test/lib/lang_test.rb
+++ b/test/lib/lang_test.rb
@@ -342,45 +342,19 @@ module Wovnrb
                 <div><p>Hello</p></div>
               </body></html>"
         when "ignore_parent_translated_in_japanese"
-          body = "<html lang=\"ja\">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\">
-<link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\">
-</head>
-<body>
-<h1>
-<!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
+          body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\"></head><body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
                 <div wovn-ignore=\"\"><p>Hello</p></div>
-              </body>
-</html>
+              </body></html>
 "
         when "translated_in_japanese"
-          body = "<html lang=\"ja\">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\">
-<link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\">
-</head>
-<body>
-<h1>
-<!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
+          body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\"></head><body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
                 <div><p><!--wovn-src:Hello-->こんにちは</p></div>
-              </body>
-</html>
+              </body></html>
 "
         when "ignore_everything_translated"
-          body = "<html lang=\"ja\">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\">
-<link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\">
-</head>
-<body wovn-ignore=\"\">
-<h1>Mr. Belvedere Fan Club</h1>
+          body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\"></head><body wovn-ignore=\"\"><h1>Mr. Belvedere Fan Club</h1>
                 <div><p>Hello</p></div>
-              </body>
-</html>
+              </body></html>
 "
         when "empty"
           body = "<html><body><h1>Mr.BelvedereFanClub</h1><div wovn-ignore><p>Hello</p></div></body></html>"
@@ -393,18 +367,17 @@ module Wovnrb
         when "value_double_quote"
           body = "<html><body><h1>Mr.BelvedereFanClub</h1><div wovn-ignore=\"value\"><p>Hello</p></div></body></html>"
         when "empty_translated"
-          body = "<html lang=\"ja\">\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\">\n<link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\">\n</head>\n<body>\n<h1>Mr.BelvedereFanClub</h1>\n<div wovn-ignore=\"\"><p>Hello</p></div>\n</body>\n</html>\n"
+          body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\"></head><body><h1>Mr.BelvedereFanClub</h1><div wovn-ignore=\"\"><p>Hello</p></div></body></html>\n"
         when "empty_single_quote_translated"
-          body = "<html lang=\"ja\">\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\">\n<link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\">\n</head>\n<body>\n<h1>Mr.BelvedereFanClub</h1>\n<div wovn-ignore=\"\"><p>Hello</p></div>\n</body>\n</html>\n"
+          body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\"></head><body><h1>Mr.BelvedereFanClub</h1><div wovn-ignore=\"\"><p>Hello</p></div></body></html>\n"
         when "empty_double_quote_translated"
-          body = "<html lang=\"ja\">\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\">\n<link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\">\n</head>\n<body>\n<h1>Mr.BelvedereFanClub</h1>\n<div wovn-ignore=\"\"><p>Hello</p></div>\n</body>\n</html>\n"
+          body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\"></head><body><h1>Mr.BelvedereFanClub</h1><div wovn-ignore=\"\"><p>Hello</p></div></body></html>\n"
         when "value_single_quote_translated"
-          body = "<html lang=\"ja\">\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\">\n<link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\">\n</head>\n<body>\n<h1>Mr.BelvedereFanClub</h1>\n<div wovn-ignore=\"value\"><p>Hello</p></div>\n</body>\n</html>\n"
+          body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\"></head><body><h1>Mr.BelvedereFanClub</h1><div wovn-ignore=\"value\"><p>Hello</p></div></body></html>\n"
         when "value_double_quote_translated"
-          body = "<html lang=\"ja\">\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\">\n<link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\">\n</head>\n<body>\n<h1>Mr.BelvedereFanClub</h1>\n<div wovn-ignore=\"value\"><p>Hello</p></div>\n</body>\n</html>\n"
+          body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.ignore-page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://ignore-page.com/\"></head><body><h1>Mr.BelvedereFanClub</h1><div wovn-ignore=\"value\"><p>Hello</p></div></body></html>\n"
         when "meta_img_alt_tags_translated"
-          body = "<html lang=\"ja\">\n<head>\n<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n<meta name=\"description\" content=\"こんにちは\">\n<meta name=\"title\" content=\"こんにちは\">\n<meta property=\"og:title\" content=\"こんにちは\">\n<meta property=\"og:description\" content=\"こんにちは\">\n<meta property=\"twitter:title\" content=\"こんにちは\">\n<meta property=\"twitter:description\" content=\"こんにちは\">\n<link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\">\n<link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\">\n</head>\n<body>\n<h1>
-<!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>\n<div><p><!--wovn-src:Hello-->こんにちは</p></div>\n<!--wovn-src:Hello--><img src=\"http://example.com/photo.png\" alt=\"こんにちは\">\n</body>\n</html>\n"
+          body = "<html lang=\"ja\"><head><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><meta name=\"description\" content=\"こんにちは\">\n<meta name=\"title\" content=\"こんにちは\">\n<meta property=\"og:title\" content=\"こんにちは\">\n<meta property=\"og:description\" content=\"こんにちは\">\n<meta property=\"twitter:title\" content=\"こんにちは\">\n<meta property=\"twitter:description\" content=\"こんにちは\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\"></head>\n<body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>\n<div><p><!--wovn-src:Hello-->こんにちは</p></div>\n<!--wovn-src:Hello--><img src=\"http://example.com/photo.png\" alt=\"こんにちは\">\n</body></html>\n"
         when  "meta_img_alt_tags"
           body = "<html><head><meta name =\"description\" content=\"Hello\">\n<meta name=\"title\" content=\"Hello\">\n<meta property=\"og:title\" content=\"Hello\">\n<meta property=\"og:description\" content=\"Hello\">\n<meta property=\"twitter:title\" content=\"Hello\">\n<meta property=\"twitter:description\" content=\"Hello\"></head>
 <body><h1>Mr. Belvedere Fan Club</h1>
@@ -416,18 +389,9 @@ module Wovnrb
                 <div><p><a href=\"javascript:void(0)\">Hello</a></p></div>
               </body></html>"
         when  "a_href_javascript_translated"
-          body = "<html lang=\"ja\">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\">
-<link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\">
-</head>
-<body>
-<h1>
-<!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
+          body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\"></head><body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
                 <div><p><a href=\"javascript:void(0)\"><!--wovn-src:Hello-->こんにちは</a></p></div>
-              </body>
-</html>
+              </body></html>
 "
         else # "" case
           body = "<html><body><h1>Mr. Belvedere Fan Club</h1>

--- a/test/lib/lang_test.rb
+++ b/test/lib/lang_test.rb
@@ -2,9 +2,10 @@
 require 'test_helper'
 require 'minitest/autorun'
 
+require 'wovnrb/helpers/nokogumbo_helper'
+
 module Wovnrb
   class LangTest < WovnMiniTest
-
     def test_langs_exist
       refute_nil(Wovnrb::Lang::LANG)
     end
@@ -464,6 +465,16 @@ module Wovnrb
       url = h.url
       swapped_body = lang.switch_dom_lang(dom, Store.instance, values, url, h)
       assert_equal(generate_body('translated_in_japanese'), swapped_body)
+    end
+
+    def test_switch_lang_with_html_fragment
+      lang = Lang.new('ja')
+      h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
+      dom = Helpers::NokogumboHelper::parse_html('<span>Hello</span>')
+      values = generate_values
+      url = h.url
+      swapped_body = lang.switch_dom_lang(dom, Store.instance, values, url, h)
+      assert_equal('<span><!--wovn-src:Hello-->こんにちは</span>', swapped_body)
     end
 
     def test_switch_lang_href_javascript

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -205,6 +205,34 @@ class WovnrbTest < Minitest::Test
     assert_equal([expected_body], swapped_body)
   end
 
+  def test_switch_lang_on_fragment_with_translate_fragment_false
+    Wovnrb::Store.instance.settings['translate_fragment'] = false
+    i = Wovnrb::Interceptor.new(get_app)
+    h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
+    body =  "<h1>Mr. Belvedere Fan Club</h1>
+                <div><p>Hello</p></div>"
+    values = generate_values
+    url = h.url
+    swapped_body = i.switch_lang([body], values, url, 'ja', h)
+
+    assert_equal([body], swapped_body)
+  end
+
+  def test_switch_lang_on_fragment_with_translate_fragment_true
+    Wovnrb::Store.instance.settings['translate_fragment'] = true
+    i = Wovnrb::Interceptor.new(get_app)
+    h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
+    body =  "<h1>Mr. Belvedere Fan Club</h1>
+                <div><p>Hello</p></div>"
+    values = generate_values
+    url = h.url
+    swapped_body = i.switch_lang([body], values, url, 'ja', h)
+    expected_body = "<h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
+                <div><p><!--wovn-src:Hello-->こんにちは</p></div>"
+
+    assert_equal([expected_body], swapped_body)
+  end
+
   def test_switch_lang_ignores_amp
     interceptor = Wovnrb::Interceptor.new(get_app)
     headers = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -137,6 +137,29 @@ class WovnrbTest < Minitest::Test
     assert_equal([expected_body], swapped_body)
   end
 
+  def test_switch_lang_of_html_fragment_with_no_translation_values
+    i = Wovnrb::Interceptor.new(get_app)
+    h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
+    body = '<select name="test"><option value="1">1</option><option value="2">2</option></select>'
+    values = {}
+    url = h.url
+    swapped_body = i.switch_lang([body], values, url, 'ja', h)
+
+    assert_equal([body], swapped_body)
+  end
+
+  def test_switch_lang_of_html_fragment_with_japanese_translations
+    i = Wovnrb::Interceptor.new(get_app)
+    h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
+    body = '<span>Hello</span>'
+    expected_body = '<span><!--wovn-src:Hello-->こんにちは</span>'
+    values = generate_values
+    url = h.url
+    swapped_body = i.switch_lang([body], values, url, 'ja', h)
+
+    assert_equal([expected_body], swapped_body)
+  end
+
   def test_switch_lang_splitted_body
     i = Wovnrb::Interceptor.new(get_app)
     h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
@@ -149,6 +172,19 @@ class WovnrbTest < Minitest::Test
 
     expected_body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\"></head><body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1><div><p><!--wovn-src:Hello-->こんにちは</p></div></body></html>
 "
+    assert_equal([expected_body], swapped_body)
+  end
+
+  def test_switch_lang_of_html_fragment_in_splitted_body
+    i = Wovnrb::Interceptor.new(get_app)
+    h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://page.com'), Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
+    bodies =  ['<select name="test"><option value="1">1</option>',
+               '<option value="2">2</option></select>']
+    expected_body = '<select name="test"><option value="1">1</option><option value="2">2</option></select>'
+    values = generate_values
+    url = h.url
+    swapped_body = i.switch_lang(bodies, values, url, 'ja', h)
+
     assert_equal([expected_body], swapped_body)
   end
 

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -130,18 +130,9 @@ class WovnrbTest < Minitest::Test
     url = h.url
     swapped_body = i.switch_lang([body], values, url, 'ja', h)
 
-    expected_body = "<html lang=\"ja\">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\">
-<link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\">
-</head>
-<body>
-<h1>
-<!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
+    expected_body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\"></head><body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
                 <div><p><!--wovn-src:Hello-->こんにちは</p></div>
-              </body>
-</html>
+              </body></html>
 "
     assert_equal([expected_body], swapped_body)
   end
@@ -156,18 +147,7 @@ class WovnrbTest < Minitest::Test
     url = h.url
     swapped_body = i.switch_lang(bodies, values, url, 'ja', h)
 
-    expected_body = "<html lang=\"ja\">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\">
-<link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\">
-</head>
-<body>
-<h1>
-<!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
-<div><p><!--wovn-src:Hello-->こんにちは</p></div>
-</body>
-</html>
+    expected_body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\"></head><body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1><div><p><!--wovn-src:Hello-->こんにちは</p></div></body></html>
 "
     assert_equal([expected_body], swapped_body)
   end
@@ -253,19 +233,9 @@ HTML
     url = h.url
     swapped_body = i.switch_lang([body], values, url, 'ja', h)
 
-    expected_body = "<html lang=\"ja\">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><noscript><div>test</div></noscript>
-<link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\">
-<link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\">
-</head>
-<body>
-<h1>
-<!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
+    expected_body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><noscript><div>test</div></noscript><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\"></head><body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
                 <div><p><!--wovn-src:Hello-->こんにちは</p></div>
-              </body>
-</html>
+              </body></html>
 "
     assert_equal([expected_body], swapped_body)
   end
@@ -282,21 +252,11 @@ HTML
     url = h.url
     swapped_body = i.switch_lang([body], values, url, 'ja', h)
 
-    expected_body = "<html lang=\"ja\">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><noscript>
+    expected_body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><noscript>
                 <div>test</div>
-                </noscript>
-<link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\">
-<link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\">
-</head>
-<body>
-<h1>
-<!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
+                </noscript><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\"></head><body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
                 <div><p><!--wovn-src:Hello-->こんにちは</p></div>
-              </body>
-</html>
+              </body></html>
 "
     assert_equal([expected_body], swapped_body)
   end
@@ -311,21 +271,9 @@ HTML
     url = h.url
     swapped_body = i.switch_lang([body], values, url, 'ja', h)
 
-    expected_body = "<html lang=\"ja\">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><noscript><div>test</div></noscript>
-<title>plop</title>
-<noscript><div>test2</div></noscript>
-<link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\">
-<link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\">
-</head>
-<body>
-<h1>
-<!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
+    expected_body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><noscript><div>test</div></noscript><title>plop</title><noscript><div>test2</div></noscript><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\"></head><body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
                 <div><p><!--wovn-src:Hello-->こんにちは</p></div>
-              </body>
-</html>
+              </body></html>
 "
     assert_equal([expected_body], swapped_body)
   end
@@ -340,19 +288,9 @@ HTML
     url = h.url
     swapped_body = i.switch_lang([body], values, url, 'ja', h)
 
-    expected_body = "<html lang=\"ja\">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><noscript><!-- --><div>test</div></noscript>
-<link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\">
-<link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\">
-</head>
-<body>
-<h1>
-<!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
+    expected_body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><noscript><!-- --><div>test</div></noscript><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\"></head><body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
                 <div><p><!--wovn-src:Hello-->こんにちは</p></div>
-              </body>
-</html>
+              </body></html>
 "
     assert_equal([expected_body], swapped_body)
   end
@@ -367,18 +305,9 @@ HTML
     url = h.url
     swapped_body = i.switch_lang([body], values, url, 'ja', h)
 
-    expected_body = "<html lang=\"ja\">
-<head>
-<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
-<script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><!--<noscript><div>test</div></noscript>--><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\">
-<link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\">
-</head>
-<body>
-<h1>
-<!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
+    expected_body = "<html lang=\"ja\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=#{Wovnrb::VERSION}\"> </script><!--<noscript><div>test</div></noscript>--><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.page.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://page.com/\"></head><body><h1><!--wovn-src:Mr. Belvedere Fan Club-->ベルベデアさんファンクラブ</h1>
                 <div><p><!--wovn-src:Hello-->こんにちは</p></div>
-              </body>
-</html>
+              </body></html>
 "
     assert_equal([expected_body], swapped_body)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,7 @@ require 'wovnrb/html_replacers/text_replacer'
 require 'wovnrb/html_replacers/meta_replacer'
 require 'wovnrb/html_replacers/image_replacer'
 require 'wovnrb/html_replacers/script_replacer'
+require 'wovnrb/helpers/nokogumbo_helper'
 require 'minitest/autorun'
 
 


### PR DESCRIPTION
### Purpose/goal of Pull Request
Prevent bug where multiple snippets are inserted and HTML structure is corrupted by wovnrb intercepting HTML fragment.

### Comments
This PR detects HTML fragments and parse them as is to avoid adding extra `<html>`, `head` and `body` tags with Nokogumbo.

Widget snippet is never added to HTML fragment .

HTML fragments are translated by default, user can disable it by setting option `translate_fragment` to `false`.