### PR TITLE
Add base href tag support

### DIFF
--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -8,6 +8,7 @@ module Wovnrb
     attr_reader :host
     attr_reader :unmasked_pathname
     attr_reader :pathname
+    attr_reader :dirname
     attr_reader :redis_url
 
     # Generates new instance of Wovnrb::Headers.
@@ -231,6 +232,13 @@ module Wovnrb
       headers
     end
 
+    def dirname
+      if pathname.include?('/')
+        pathname.end_with?('/') ? pathname : pathname[0, pathname.rindex('/') + 1]
+      else
+        '/'
+      end
+    end
   end
 
 end

--- a/lib/wovnrb/html_replacers/link_replacer.rb
+++ b/lib/wovnrb/html_replacers/link_replacer.rb
@@ -58,21 +58,7 @@ module Wovnrb
       return href if href =~ /^\//            # absolute path
       return href if href =~ /^http(s?):\/\// # full url
 
-      abs_path = Addressable::URI.join('/', @headers.dirname, href).to_s
-      strip_relative_path_jumps(abs_path)
-    end
-
-    def strip_relative_path_jumps(path)
-      components = path.split('/') - ['.', '']
-      while components.index('..')
-        if components.index('..').zero?
-          components.shift
-        else
-          components.slice!(components.index('..') - 1, 2)
-        end
-      end
-
-      Addressable::URI.join('/', components.join('/')).to_s
+      Addressable::URI.join('/', @headers.dirname, href).to_s
     end
   end
 

--- a/lib/wovnrb/html_replacers/link_replacer.rb
+++ b/lib/wovnrb/html_replacers/link_replacer.rb
@@ -54,11 +54,11 @@ module Wovnrb
       base_tag = dom.xpath('//base').first
       return nil unless base_tag
 
-      href= base_tag.get_attribute('href')
+      href = base_tag.get_attribute('href')
       return href if href =~ /^\//            # absolute path
       return href if href =~ /^http(s?):\/\// # full url
 
-      abs_path = File.join('/', @headers.dirname, href)
+      abs_path = Addressable::URI.join('/', @headers.dirname, href).to_s
       strip_relative_path_jumps(abs_path)
     end
 
@@ -72,10 +72,7 @@ module Wovnrb
         end
       end
 
-      stripped_path = File.join('/', components)
-      stripped_path += '/' if path.end_with?('/') && stripped_path.length > 1
-
-      stripped_path
+      Addressable::URI.join('/', components.join('/')).to_s
     end
   end
 

--- a/lib/wovnrb/html_replacers/link_replacer.rb
+++ b/lib/wovnrb/html_replacers/link_replacer.rb
@@ -13,7 +13,10 @@ module Wovnrb
       @headers = headers
     end
 
+
     def replace(dom, lang)
+      base_url = base_href(dom)
+
       dom.xpath('//*[match(.)]', MultiTagMatcher.new).each do |node|
         next if wovn_ignore?(node)
 
@@ -21,9 +24,22 @@ module Wovnrb
         next if href =~ /^\s*\{\{.+\}\}\s*$/
         next if href =~ /^\s*javascript:/i
         next if is_file?(href)
-        new_href = lang.add_lang_code(href, @pattern, @headers)
+
+        new_href = href
+        new_href = adjust_link_by_base(new_href, base_url) if base_url
+        new_href = lang.add_lang_code(new_href, @pattern, @headers)
+
         node.set_attribute('href', new_href)
       end
+    end
+
+    private
+
+    def adjust_link_by_base(href, base_url)
+      return href if href =~ /^\//            # absolute path
+      return href if href =~ /^http(s?):\/\// # full url
+
+      File.join(base_url, href)
     end
 
     def is_file?(href)
@@ -32,6 +48,34 @@ module Wovnrb
       video_files = /^(https?:\/\/)?.*(\.(#{FileExtension::VIDEO_FILES}))((\?|#).*)?$/i
       doc_files = /^(https?:\/\/)?.*(\.(#{FileExtension::DOC_FILES}))((\?|#).*)?$/i
       href =~ img_files || href =~ audio_files || href =~ video_files || href =~ doc_files
+    end
+
+    def base_href(dom)
+      base_tag = dom.xpath('//base').first
+      return nil unless base_tag
+
+      href= base_tag.get_attribute('href')
+      return href if href =~ /^\//            # absolute path
+      return href if href =~ /^http(s?):\/\// # full url
+
+      abs_path = File.join('/', @headers.dirname, href)
+      strip_relative_path_jumps(abs_path)
+    end
+
+    def strip_relative_path_jumps(path)
+      components = path.split('/') - ['.', '']
+      while components.index('..')
+        if components.index('..').zero?
+          components.shift
+        else
+          components.slice!(components.index('..') - 1, 2)
+        end
+      end
+
+      stripped_path = File.join('/', components)
+      stripped_path += '/' if path.end_with?('/') && stripped_path.length > 1
+
+      stripped_path
     end
   end
 

--- a/lib/wovnrb/lang.rb
+++ b/lib/wovnrb/lang.rb
@@ -153,6 +153,7 @@ module Wovnrb
             end
         end
       end
+
       new_href
     end
 

--- a/test/lib/html_replacers/link_replacer_test.rb
+++ b/test/lib/html_replacers/link_replacer_test.rb
@@ -254,10 +254,53 @@ module Wovnrb
       assert_equal(' {{hello}} ', link)
     end
 
+    def test_with_base_as_previous_directory
+      dom, replacer = create_dom_by_base(base: '../', href: 'm/css/iphone.css')
+      replacer.replace(dom, Lang.new('en'))
 
+      assert_link(dom, '/en/sp/entry2017/m/css/iphone.css')
+    end
 
-    def get_header
-      h = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://favy.tips'), Wovnrb.get_settings('url_pattern' => 'query', 'url_pattern_reg' => '^(?<lang>[^.]+).'))
+    def test_with_base_as_different_host
+      dom, replacer = create_dom_by_base(base: 'http://test.com', href: 'm/css/iphone.css')
+      replacer.replace(dom, Lang.new('en'))
+
+      assert_link(dom, 'http://test.com/m/css/iphone.css')
+    end
+
+    def test_with_base_as_different_host_without_protocol
+      dom, replacer = create_dom_by_base(base: '//test.com', href: 'm/css/iphone.css')
+      replacer.replace(dom, Lang.new('en'))
+      assert_link(dom, '//test.com/m/css/iphone.css')
+    end
+
+    def test_with_base_as_relative_path
+      dom, replacer = create_dom_by_base(base: '/test', href: 'm/css/iphone.css')
+      replacer.replace(dom, Lang.new('en'))
+      assert_link(dom, '/en/test/m/css/iphone.css')
+    end
+
+    def test_with_base_as_relative_path_without_starting_slash
+      dom, replacer = create_dom_by_base(base: 'test/', href: 'm/css/iphone.css')
+      replacer.replace(dom, Lang.new('en'))
+      assert_link(dom, '/en/sp/entry2017/m/test/m/css/iphone.css')
+    end
+
+    def get_header(url_pattern: 'query', pathname: nil)
+      h = Wovnrb::Headers.new(Wovnrb.get_env('url' => "http://favy.tips#{pathname}"), Wovnrb.get_settings('url_pattern' => url_pattern, 'url_pattern_reg' => '^(?<lang>[^.]+).'))
+    end
+
+    def create_dom_by_base(base:, href:)
+      store = Store.instance
+      replacer = LinkReplacer.new(store, 'path', get_header(url_pattern: 'path', pathname: '/sp/entry2017/m/index.php'))
+      dom = Wovnrb.get_dom("<base target=\"_blank\" href=\"#{base}\"><a href=\"#{href}\">link text</a>")
+
+      [dom, replacer]
+    end
+
+    def assert_link(dom, expected)
+      link = dom.xpath('//a')[0].get_attribute('href')
+      assert_equal(expected, link)
     end
   end
 end

--- a/test/lib/html_replacers/link_replacer_test.rb
+++ b/test/lib/html_replacers/link_replacer_test.rb
@@ -257,14 +257,12 @@ module Wovnrb
     def test_with_base_as_previous_directory
       dom, replacer = create_dom_by_base(base: '../', href: 'm/css/iphone.css')
       replacer.replace(dom, Lang.new('en'))
-
       assert_link(dom, '/en/sp/entry2017/m/css/iphone.css')
     end
 
     def test_with_base_as_different_host
       dom, replacer = create_dom_by_base(base: 'http://test.com', href: 'm/css/iphone.css')
       replacer.replace(dom, Lang.new('en'))
-
       assert_link(dom, 'http://test.com/m/css/iphone.css')
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+require 'pry'
 
 # save to CircleCI's artifacts directory if we're on CircleCI
 if ENV['CIRCLE_ARTIFACTS']

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -47,6 +47,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-remote"
   spec.add_development_dependency "pry-nav"
+  spec.add_development_dependency "pry-byebug"
+
   #spec.add_development_dependency "rice"
   spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "timecop"


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)

Support `base` tag

> The HTML <base> element specifies the base URL to use for all relative URLs contained within a document. There can be only one <base> element in a document.
> -- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base

### Comments
