### PR TITLE
Use latest compatible Nokogumbo version

### DIFF
--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   #spec.extensions    = %w[ext/dom/extconf.rb]
   #spec.extensions    = spec.files.grep(%r{/extconf\.rb$})
 
-  spec.add_dependency "nokogumbo", "~> 1.5.0"
+  spec.add_dependency "nokogumbo", ">= 1.4.0", "< 2.0.0"
   spec.add_dependency "nokogiri", "~> 1.8.1"
   spec.add_dependency "activesupport"
   spec.add_dependency "lz4-ruby"

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   #spec.extensions    = %w[ext/dom/extconf.rb]
   #spec.extensions    = spec.files.grep(%r{/extconf\.rb$})
 
-  spec.add_dependency "nokogumbo", ">= 1.3.0"
+  spec.add_dependency "nokogumbo", "~> 1.5.0"
   spec.add_dependency "nokogiri", "~> 1.8.1"
   spec.add_dependency "activesupport"
   spec.add_dependency "lz4-ruby"


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)

### Comments
With recent update of Nokogumbo to 2.0.0, test no longer pass. This
change is to keep using older version of Nokogumbo that passes the tests
until investigation on using Nokogumbo.

Even with Nokogumbo 1.3.0 test are no longer passing. I guess it comes from https://github.com/WOVNio/wovnrb/pull/123 which overrides one Nokogumbo method.