### PR TITLE
Dev Mode with Local Translation API

### DIFF
--- a/lib/wovnrb/api_translator.rb
+++ b/lib/wovnrb/api_translator.rb
@@ -27,13 +27,11 @@ module Wovnrb
           response_body = Zlib::GzipReader.new(StringIO.new(response.body)).read
 
           JSON.parse(response_body)['body'] || body
+        elsif @store.dev_mode?
+          JSON.parse(response.body)['body'] || body
         else
-          if @store.dev_mode?
-            JSON.parse(response.body)['body'] || body
-          else
-            WovnLogger.error("Received invalid content (\"#{response.header['Content-Encoding']}\") from WOVNio translation API.")
-            body
-          end
+          WovnLogger.error("Received invalid content (\"#{response.header['Content-Encoding']}\") from WOVNio translation API.")
+          body
         end
       else
         WovnLogger.error("Received \"#{response.message}\" from WOVNio translation API.")

--- a/lib/wovnrb/api_translator.rb
+++ b/lib/wovnrb/api_translator.rb
@@ -28,8 +28,12 @@ module Wovnrb
 
           JSON.parse(response_body)['body'] || body
         else
-          WovnLogger.error("Received invalid content (\"#{response.header['Content-Encoding']}\") from WOVNio translation API.")
-          body
+          if @store.dev_mode?
+            JSON.parse(response.body)['body'] || body
+          else
+            WovnLogger.error("Received invalid content (\"#{response.header['Content-Encoding']}\") from WOVNio translation API.")
+            body
+          end
         end
       else
         WovnLogger.error("Received \"#{response.message}\" from WOVNio translation API.")

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -153,6 +153,16 @@ module Wovnrb
                                else
                                  true
                                end
+
+      if @settings['wovn_dev_mode']
+        if @settings['api_url'] == self.class.default_settings['api_url']
+          @settings['api_url'] = 'http://dev-wovn.io:3001/v0/'
+        end
+
+        if @settings['api_timeout_seconds'] == self.class.default_settings['api_timeout_seconds']
+          @settings['api_timeout_seconds'] = 3
+        end
+      end
     end
 
     def custom_lang_aliases
@@ -178,6 +188,10 @@ module Wovnrb
       else
         'wovn.io'
       end
+    end
+
+    def dev_mode?
+      @settings['wovn_dev_mode']
     end
 
     private

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -20,8 +20,7 @@ module Wovnrb
     end
 
     def test_translate_accepts_uncompressed_response_from_api_in_dev_mode
-      store = Wovnrb::Store.instance.update_settings({ 'wovn_dev_mode' => true })
-
+      Wovnrb::Store.instance.update_settings('wovn_dev_mode' => true)
       assert_translation('test.html', 'test_translated.html', true, encoding: 'text/json')
     end
 

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -19,6 +19,12 @@ module Wovnrb
       assert_translation('test.html', 'test_translated.html', false, encoding: 'unknown')
     end
 
+    def test_translate_accepts_uncompressed_response_from_api_in_dev_mode
+      store = Wovnrb::Store.instance.update_settings({ 'wovn_dev_mode' => true })
+
+      assert_translation('test.html', 'test_translated.html', true, encoding: 'text/json')
+    end
+
     private
 
     def assert_translation(original_html_fixture, translated_html_fixture, success_expected, response = { encoding: 'gzip', status_code: 200 })
@@ -58,7 +64,12 @@ module Wovnrb
     def stub_translation_api_request(store, headers, original_html, translated_html, response)
       if response
         cache_key = generate_cache_key(store, original_html)
-        api_url = "wovn.global.ssl.fastly.net/v0/translation?cache_key=#{cache_key}"
+        api_host = if store.dev_mode?
+                     'dev-wovn.io:3001'
+                   else
+                     'wovn.global.ssl.fastly.net'
+                   end
+        api_url = "http://#{api_host}/v0/translation?cache_key=#{cache_key}"
         compressed_data = compress(generate_data(original_html))
         headers = {
           'Accept' => '*/*',
@@ -67,11 +78,16 @@ module Wovnrb
           'Content-Type' => 'application/octet-stream',
           'User-Agent' => 'Ruby'
         }
-        compressed_response = compress("{\"body\":\"#{translated_html.gsub("\n", '\n')}\"}")
+        stub_response_json = "{\"body\":\"#{translated_html.gsub("\n", '\n')}\"}"
+        stub_response = if store.dev_mode?
+                          stub_response_json
+                        else
+                          compress(stub_response_json)
+                        end
         response_headers = { 'Content-Encoding' => response[:encoding] || 'gzip' }
         stub = stub_request(:post, api_url)
                .with(body: compressed_data, headers: headers)
-               .to_return(status: response[:status_code] || 200, body: compressed_response, headers: response_headers)
+               .to_return(status: response[:status_code] || 200, body: stub_response, headers: response_headers)
 
         stub
       end

--- a/test/lib/store_test.rb
+++ b/test/lib/store_test.rb
@@ -104,6 +104,42 @@ module Wovnrb
       assert_equal([], s.settings['ignore_globs'])
     end
 
+    def test_default_dev_mode_settings
+      store = Wovnrb::Store.instance
+
+      store.update_settings({ 'wovn_dev_mode' => true })
+
+      assert(store.dev_mode?)
+      assert_equal('http://dev-wovn.io:3001/v0/', store.settings['api_url'])
+      assert_equal(3, store.settings['api_timeout_seconds'])
+    end
+
+    def test_dev_mode_not_overriding_settings
+      store = Wovnrb::Store.instance
+
+      store.update_settings({
+        'wovn_dev_mode' => true,
+        'api_url' => 'http://my-test-api.wovn.io/v0/',
+        'api_timeout_seconds' => 42
+      })
+
+      assert(store.dev_mode?)
+      assert_equal('http://my-test-api.wovn.io/v0/', store.settings['api_url'])
+      assert_equal(42, store.settings['api_timeout_seconds'])
+    end
+
+    def test_dev_mode?
+      store = Wovnrb::Store.instance
+
+      assert_equal(false, store.settings['wovn_dev_mode'])
+      assert(!store.dev_mode?)
+
+      store.update_settings({ 'wovn_dev_mode' => true })
+
+      assert_equal(true, store.settings['wovn_dev_mode'])
+      assert(store.dev_mode?)
+    end
+
     def test_valid_user_token
       mock = LogMock.mock_log
       store = Wovnrb::Store.instance

--- a/test/lib/store_test.rb
+++ b/test/lib/store_test.rb
@@ -107,7 +107,7 @@ module Wovnrb
     def test_default_dev_mode_settings
       store = Wovnrb::Store.instance
 
-      store.update_settings({ 'wovn_dev_mode' => true })
+      store.update_settings('wovn_dev_mode' => true)
 
       assert(store.dev_mode?)
       assert_equal('http://dev-wovn.io:3001/v0/', store.settings['api_url'])
@@ -117,11 +117,11 @@ module Wovnrb
     def test_dev_mode_not_overriding_settings
       store = Wovnrb::Store.instance
 
-      store.update_settings({
+      store.update_settings(
         'wovn_dev_mode' => true,
         'api_url' => 'http://my-test-api.wovn.io/v0/',
         'api_timeout_seconds' => 42
-      })
+      )
 
       assert(store.dev_mode?)
       assert_equal('http://my-test-api.wovn.io/v0/', store.settings['api_url'])
@@ -134,7 +134,7 @@ module Wovnrb
       assert_equal(false, store.settings['wovn_dev_mode'])
       assert(!store.dev_mode?)
 
-      store.update_settings({ 'wovn_dev_mode' => true })
+      store.update_settings('wovn_dev_mode' => true)
 
       assert_equal(true, store.settings['wovn_dev_mode'])
       assert(store.dev_mode?)


### PR DESCRIPTION
### Purpose/goal of Pull Request
Directly use local server for Translation API in dev mode (avoid extra setup).

### Comments
Current Translation API does not compress content in development environment, so I added that case to `ApiTranslator`.