### PR TITLE
[wip] Feature/check href for ignored urls and paths

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -70,6 +70,10 @@ module Wovnrb
         return output(headers, status, res_headers, body)
       end
 
+      if @store.ignored_urls.any?{|ignored_url| headers.url =~ /#{ignored_url}/i}
+        return output(headers, status, res_headers, body)
+      end
+
       # ApiData creates request for external server, but cannot use async.
       # Because some server not allow multi thread. (env['async.callback'] is not supported at all Server).
       api_data = ApiData.new(headers.redis_url, @store)

--- a/lib/wovnrb/html_replacers/link_replacer.rb
+++ b/lib/wovnrb/html_replacers/link_replacer.rb
@@ -13,7 +13,6 @@ module Wovnrb
       @headers = headers
     end
 
-
     def replace(dom, lang)
       base_url = base_href(dom)
 
@@ -35,11 +34,27 @@ module Wovnrb
 
     private
 
+    def wovn_ignore?(node)
+      return super(node) || is_ignored_href?(node.get_attribute('href'))
+    end
+
+    def is_ignored_href?(href)
+      if absolute_url?(href)
+        # TODO: check ignored_urls, then ignored_paths
+      end
+
+      return @store.ignored_paths.any? { |p| href =~ /#{p}/i }
+    end
+
     def adjust_link_by_base(href, base_url)
       return href if href =~ /^\//            # absolute path
-      return href if href =~ /^http(s?):\/\// # full url
+      return href if absolute_url?(href)
 
       File.join(base_url, href)
+    end
+
+    def absolute_url?(href)
+      return href =~ /^http(s?):\/\//
     end
 
     def is_file?(href)

--- a/lib/wovnrb/html_replacers/link_replacer.rb
+++ b/lib/wovnrb/html_replacers/link_replacer.rb
@@ -39,11 +39,13 @@ module Wovnrb
     end
 
     def is_ignored_href?(href)
+      result = false
       if absolute_url?(href)
-        # TODO: check ignored_urls, then ignored_paths
+        result ||= @store.ignored_urls.any? { |u| href =~ /#{u}/i }
       end
+      result ||= @store.ignored_paths.any? { |p| href =~ /#{p}/i }
 
-      return @store.ignored_paths.any? { |p| href =~ /#{p}/i }
+      result
     end
 
     def adjust_link_by_base(href, base_url)

--- a/lib/wovnrb/html_replacers/replacer_base.rb
+++ b/lib/wovnrb/html_replacers/replacer_base.rb
@@ -1,8 +1,8 @@
 module Wovnrb
   class ReplacerBase
-    def initialize(store, ignored_class_set = [])
+    def initialize(store)
       @store = store
-      @ignored_class_set = Set.new(ignored_class_set)
+      @ignored_class_set = Set.new(@store.ignored_classes)
     end
 
     def replace(dom, lang)
@@ -19,12 +19,7 @@ module Wovnrb
 
       node_class = node.get_attribute('class')
       if node_class
-        classes = node_class.split
-        @store.settings['ignore_class'].each do |ignore_class|
-          if classes.include?(ignore_class)
-            return true
-          end
-        end
+        return node_class.split.any? { |c| @ignored_class_set.include?(c) }
       end
 
       wovn_ignore?(node.parent)

--- a/lib/wovnrb/settings.rb
+++ b/lib/wovnrb/settings.rb
@@ -32,6 +32,7 @@ module Wovnrb
     DYNAMIC_KEYS = {
       'wovn_token' => 'project_token',
       'wovn_ignore_paths' => 'ignore_paths',
+      'wovn_ignored_urls' => 'ignored_urls'
     }
   end
 end

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -171,6 +171,10 @@ module Wovnrb
       @settings['ignore_class']
     end
 
+    def ignored_urls
+      @settings['ignored_urls']
+    end
+
     def wovn_protocol
       wovn_dev_mode? ? 'http' : 'https'
     end

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -163,6 +163,14 @@ module Wovnrb
       @settings['wovn_dev_mode']
     end
 
+    def ignored_paths
+      @settings['ignore_paths']
+    end
+
+    def ignored_classes
+      @settings['ignore_class']
+    end
+
     def wovn_protocol
       wovn_dev_mode? ? 'http' : 'https'
     end

--- a/test/lib/html_replacers/link_replacer_test.rb
+++ b/test/lib/html_replacers/link_replacer_test.rb
@@ -59,6 +59,26 @@ module Wovnrb
       assert_equal('/dir/ignored_path/index.html', link)
     end
 
+    def test_href_to_ignored_url_is_not_replaced
+      @store.update_settings('ignored_urls' => ['http://ignoredsite.com'])
+      replacer = LinkReplacer.new(@store, 'query', get_header)
+      dom = Wovnrb.get_dom('<a href="http://ignoredsite.com/dir/index.html">link text</a>')
+      replacer.replace(dom, Lang.new('en'))
+
+      link = dom.xpath('//a')[0].get_attribute('href')
+      assert_equal('http://ignoredsite.com/dir/index.html', link)
+    end
+
+    def test_href_to_absolute_url_with_ignored_path_is_not_replaced
+      @store.update_settings('ignore_paths' => ['/ignored_path/'])
+      replacer = LinkReplacer.new(@store, 'query', get_header)
+      dom = Wovnrb.get_dom('<a href="http://ignoredsite.com/dir/ignored_path/index.html">link text</a>')
+      replacer.replace(dom, Lang.new('en'))
+
+      link = dom.xpath('//a')[0].get_attribute('href')
+      assert_equal('http://ignoredsite.com/dir/ignored_path/index.html', link)
+    end
+
     def test_replace_empty_javascript_link_query
       replacer = LinkReplacer.new(@store, 'query', get_header)
       dom = Wovnrb.get_dom('<a href="javascript:void(0);">link text</a>')

--- a/test/lib/html_replacers/link_replacer_test.rb
+++ b/test/lib/html_replacers/link_replacer_test.rb
@@ -3,9 +3,14 @@ require 'webmock/minitest'
 
 module Wovnrb
   class ReplacerBaseTest < WovnMiniTest
+    def before_setup
+      super
+
+      @store = Store.instance
+    end
+
     def test_replace
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'query', get_header)
+      replacer = LinkReplacer.new(@store, 'query', get_header)
       dom = Wovnrb.get_dom('<a href="/index.html">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -14,8 +19,7 @@ module Wovnrb
     end
 
     def test_replace_multiple
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'query', get_header)
+      replacer = LinkReplacer.new(@store, 'query', get_header)
       dom = Wovnrb.get_dom('<a href="/index.html">link text</a><div>aaa</div><a href="/index2.html">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -27,8 +31,7 @@ module Wovnrb
     end
 
     def test_replace_ignore
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'query', get_header)
+      replacer = LinkReplacer.new(@store, 'query', get_header)
       dom = Wovnrb.get_dom('<a wovn-ignore href="/index.html">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -36,9 +39,28 @@ module Wovnrb
       assert_equal('/index.html', link)
     end
 
+    def test_replace_ignored_class_is_not_replaced
+      @store.update_settings('ignore_class' => ['ignored-class'])
+      replacer = LinkReplacer.new(@store, 'query', get_header)
+      dom = Wovnrb.get_dom('<a class="ignored-class" href="/index.html">link text</a>')
+      replacer.replace(dom, Lang.new('en'))
+
+      link = dom.xpath('//a')[0].get_attribute('href')
+      assert_equal('/index.html', link)
+    end
+
+    def test_href_to_ignored_path_is_not_replaced
+      @store.update_settings('ignore_paths' => ['/ignored_path/'])
+      replacer = LinkReplacer.new(@store, 'query', get_header)
+      dom = Wovnrb.get_dom('<a href="/dir/ignored_path/index.html">link text</a>')
+      replacer.replace(dom, Lang.new('en'))
+
+      link = dom.xpath('//a')[0].get_attribute('href')
+      assert_equal('/dir/ignored_path/index.html', link)
+    end
+
     def test_replace_empty_javascript_link_query
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'query', get_header)
+      replacer = LinkReplacer.new(@store, 'query', get_header)
       dom = Wovnrb.get_dom('<a href="javascript:void(0);">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -47,8 +69,7 @@ module Wovnrb
     end
 
     def test_replace_javascript_code_link_query
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'query', get_header)
+      replacer = LinkReplacer.new(@store, 'query', get_header)
       dom = Wovnrb.get_dom('<a href="javascript:onclick($(\'.any\').slideToggle());">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -57,8 +78,7 @@ module Wovnrb
     end
 
     def test_replace_uppercased_javascript_code_link_query
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'query', get_header)
+      replacer = LinkReplacer.new(@store, 'query', get_header)
       dom = Wovnrb.get_dom('<a href="JAVASCRIPT:onclick($(\'.any\').slideToggle());">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -67,8 +87,7 @@ module Wovnrb
     end
 
     def test_replace_empty_javascript_link_path
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="javascript:void(0);">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -77,8 +96,7 @@ module Wovnrb
     end
 
     def test_replace_javascript_code_link_path
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="javascript:onclick($(\'.any\').slideToggle());">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -87,8 +105,7 @@ module Wovnrb
     end
 
     def test_replace_uppercased_javascript_code_link_path
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="JAVASCRIPT:onclick($(\'.any\').slideToggle());">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -97,8 +114,7 @@ module Wovnrb
     end
 
     def test_replace_link_path
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="/index.html">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -107,8 +123,7 @@ module Wovnrb
     end
 
     def test_replace_link_path_with_canonical
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<html><head><link rel="canonical" href="http://wovn.io/hello/index.html"></head><body>hello</body></html>')
       replacer.replace(dom, Lang.new('en'))
       canonical_href = dom.xpath('//link').find { |d| d.attributes['rel'].value == 'canonical' }.attributes['href'].value
@@ -116,8 +131,7 @@ module Wovnrb
     end
 
     def test_replace_link_with_style
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<html><head><link rel="stylesheet" type="text/css" href="http://wovn.io/hello/index.css"></head><body>hello</body></html>')
       replacer.replace(dom, Lang.new('en'))
       href = dom.xpath('//link').find { |d| d.attributes['rel'].value == 'stylesheet' }.attributes['href'].value
@@ -125,8 +139,7 @@ module Wovnrb
     end
 
     def test_replace_img_link_path
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="http://wovn.io/index.jpg">link text</a>')
       replacer.replace(dom, Lang.new('ja'))
 
@@ -135,8 +148,7 @@ module Wovnrb
     end
 
     def test_replace_img_link_path_with_query_or_hash
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="http://wovn.io/index.jpg?test=1">link text</a>')
       replacer.replace(dom, Lang.new('ja'))
 
@@ -151,8 +163,7 @@ module Wovnrb
     end
 
     def test_replace_audio_link_path
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="/index.mp3">link text</a>')
       replacer.replace(dom, Lang.new('ja'))
 
@@ -161,8 +172,7 @@ module Wovnrb
     end
 
     def test_replace_audio_link_path_with_query_or_hash
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="/index.mp3?test=1">link text</a>')
       replacer.replace(dom, Lang.new('ja'))
 
@@ -177,8 +187,7 @@ module Wovnrb
     end
 
     def test_replace_video_link_path
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="/index.mpeg">link text</a>')
       replacer.replace(dom, Lang.new('ja'))
 
@@ -187,8 +196,7 @@ module Wovnrb
     end
 
     def test_replace_video_link_path_with_query_or_hash
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="/index.mp4?test=1">link text</a>')
       replacer.replace(dom, Lang.new('ja'))
 
@@ -203,8 +211,7 @@ module Wovnrb
     end
 
     def test_replace_doc_link_path
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="/index.pptx">link text</a>')
       replacer.replace(dom, Lang.new('ja'))
 
@@ -213,8 +220,7 @@ module Wovnrb
     end
 
     def test_replace_doc_link_path_with_query_or_hash
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header)
+      replacer = LinkReplacer.new(@store, 'path', get_header)
       dom = Wovnrb.get_dom('<a href="/index.pptx?test=1">link text</a>')
       replacer.replace(dom, Lang.new('ja'))
 
@@ -229,8 +235,7 @@ module Wovnrb
     end
 
     def test_replace_javascript_link_subdomain
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'subdomain', get_header)
+      replacer = LinkReplacer.new(@store, 'subdomain', get_header)
       dom = Wovnrb.get_dom('<a href="javascript:void(0);">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -239,8 +244,7 @@ module Wovnrb
     end
 
     def test_replace_mustache
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'query', get_header)
+      replacer = LinkReplacer.new(@store, 'query', get_header)
       dom = Wovnrb.get_dom('<a href="{{hello}}">link text</a>')
       replacer.replace(dom, Lang.new('en'))
 
@@ -285,7 +289,6 @@ module Wovnrb
     end
 
     def test_base_href
-      store = Store.instance
       tests = [
         { pathname: '/dirname/index.php', base: '/absolute/path', expected_href: '/absolute/path' },
         { pathname: '/dirname/index.php', base: 'relative/path', expected_href: '/dirname/relative/path' },
@@ -299,7 +302,7 @@ module Wovnrb
       ]
 
       tests.each do |test|
-        replacer = LinkReplacer.new(store, 'path', get_header(url_pattern: 'path', pathname: test[:pathname]))
+        replacer = LinkReplacer.new(@store, 'path', get_header(url_pattern: 'path', pathname: test[:pathname]))
         dom = Wovnrb.get_dom("<base target=\"_blank\" href=\"#{test[:base]}\"><a href=\"/not_matter\">link text</a>")
         assert_equal(test[:expected_href], replacer.send(:base_href, dom))
       end
@@ -313,8 +316,7 @@ module Wovnrb
     end
 
     def create_dom_by_base(base:, href:)
-      store = Store.instance
-      replacer = LinkReplacer.new(store, 'path', get_header(url_pattern: 'path', pathname: '/sp/entry2017/m/index.php'))
+      replacer = LinkReplacer.new(@store, 'path', get_header(url_pattern: 'path', pathname: '/sp/entry2017/m/index.php'))
       dom = Wovnrb.get_dom("<base target=\"_blank\" href=\"#{base}\"><a href=\"#{href}\">link text</a>")
 
       [dom, replacer]

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -106,6 +106,20 @@ class WovnrbTest < Minitest::Test
     assert_requested(stub, :times => 0)
   end
 
+  def test_request_wovn_ignored_urls
+    settings = Wovnrb.get_settings
+    url = 'wovn.io/dashboard'
+    stub = stub_request(:get, "#{settings['api_url']}?token=#{settings['project_token']}&url=#{url}").
+        to_return(:body => '{"test_body": "a"}')
+
+    app = get_app(:params => {'wovn_ignore_urls' => [url]})
+    i = Wovnrb::Interceptor.new(app, settings)
+
+    env = Wovnrb.get_env
+    i.call(env)
+    assert_requested(stub, :times => 0)
+  end
+
   def test_request_wovn_disable
     settings = Wovnrb.get_settings
     token = settings['project_token']


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
https://github.com/WOVNio/equalizer/issues/14706
### Comments
It already check wovn-ignore and ignored classes, but we also want to ignore links to pages that point to an ignored path or an ignored URL (the domain settings under Auto Page Add). If a link is ignored it will not have the wovn language code added to it.
I have added a new ignored_url setting to wovnrb.
