### PR TITLE
Change default API timeout to 1 second

### DIFF
--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -23,7 +23,7 @@ module Wovnrb
         'query' => [],
         'ignore_class' => [],
         'api_url' => 'https://wovn.global.ssl.fastly.net/v0/',
-        'api_timeout_seconds' => 0.5,
+        'api_timeout_seconds' => 1.0,
         'default_lang' => 'en',
         'supported_langs' => ['en'],
         'test_mode' => false,
@@ -160,7 +160,7 @@ module Wovnrb
         end
 
         if @settings['api_timeout_seconds'] == self.class.default_settings['api_timeout_seconds']
-          @settings['api_timeout_seconds'] = 3
+          @settings['api_timeout_seconds'] = 3.0
         end
       end
     end

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '2.0.3'.freeze
+  VERSION = '2.0.4'.freeze
 end


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Raise default timeout to 1.0 seconds for API requests.
Related issue: https://github.com/WOVNio/equalizer/issues/16976

Also bump patch version.