### PR TITLE
Fully ignore paths that exist with (not added by WOVN) language code

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ lang_param_name    |          | 'wovn'
 query              |          | []
 ignore_class       |          | []
 translate_fragment |          | true
+ignore_paths       |          | []
 
 ### 2.1. project_token
 
@@ -160,6 +161,17 @@ This sets "Ignore class" which prevents WOVN from translating HTML elements that
 This option allows to disable translating partial HTML content. By default,
 partial HTML content is translated but no widget snippet is added. Set
 `translate_fragment` to `false` to prevent translating partial HTML content.
+
+### 2.9 ignore_paths
+
+This parameter tells WOVN.rb to not localize content withing given directories.
+
+The directories given will only be matched against the beginning of the URL path.
+
+For instance, if you want to not localize the admin directory of your website, you should add the following to you WOVN.rb configuration.
+```
+'ignore_paths' => ['/admin/']
+```
 
 ## 3. Contributing
 

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -39,7 +39,7 @@ module Wovnrb
 
       # if path containing language code is ignored, do nothing
       if ignore_path?(headers.unmasked_pathname)
-        status, res_headers, body = @app.call(headers.request_out)
+        status, res_headers, body = @app.call(env)
 
         return output(headers, status, res_headers, body)
       end

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -113,7 +113,7 @@ module Wovnrb
     end
 
     def ignore_path?(path)
-      @store.settings['ignore_globs'].any? { |g| g.match?(path) }
+      @store.settings['ignore_globs'].ignore?(path)
     end
 
     # Checks if a given HTML body is an Accelerated Mobile Page (AMP).

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -38,7 +38,7 @@ module Wovnrb
       end
 
       # if path containing language code is ignored, do nothing
-      if ignore_path?(headers.unmasked_pathname)
+      if ignore_path?(headers.unmasked_pathname.sub(/\/$/, ''))
         status, res_headers, body = @app.call(env)
 
         return output(headers, status, res_headers, body)

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -38,7 +38,7 @@ module Wovnrb
       end
 
       # if path containing language code is ignored, do nothing
-      if ignore_path?(headers.unmasked_pathname.sub(/\/$/, ''))
+      if ignore_path?(headers.unmasked_pathname_without_trailing_slash)
         status, res_headers, body = @app.call(env)
 
         return output(headers, status, res_headers, body)

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -29,16 +29,17 @@ module Wovnrb
 
       @env = env
       headers = Headers.new(env, @store.settings)
+      default_lang = @store.settings['default_lang']
       return @app.call(env) if @store.settings['test_mode'] && @store.settings['test_url'] != headers.url
 
       # redirect if the path is set to the default language (for SEO purposes)
-      if headers.path_lang == @store.settings['default_lang']
-        redirect_headers = headers.redirect(@store.settings['default_lang'])
+      if headers.path_lang == default_lang
+        redirect_headers = headers.redirect(default_lang)
         return [307, redirect_headers, ['']]
       end
 
       # if path containing language code is ignored, do nothing
-      if ignore_path?(headers.unmasked_pathname_without_trailing_slash)
+      if headers.lang_code != default_lang && ignore_path?(headers.unmasked_pathname_without_trailing_slash)
         status, res_headers, body = @app.call(env)
 
         return output(headers, status, res_headers, body)

--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -65,6 +65,10 @@ module Wovnrb
       @redis_url = "#{@host}#{@pathname}#{@query}"
     end
 
+    def unmasked_pathname_without_trailing_slash
+      @unmasked_pathname.sub(/\/$/, '')
+    end
+
     # Get the language code of the current request
     #
     # @return [String] The lang code of the current page

--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -66,7 +66,7 @@ module Wovnrb
     end
 
     def unmasked_pathname_without_trailing_slash
-      @unmasked_pathname.sub(/\/$/, '')
+      @unmasked_pathname.chomp('/')
     end
 
     # Get the language code of the current request

--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -207,19 +207,21 @@ module Wovnrb
       r = Regexp.new('//' + @host)
       lang_code = Store.instance.settings['custom_lang_aliases'][self.lang_code] || self.lang_code
       if lang_code != @settings['default_lang'] && headers.key?('Location') && headers['Location'] =~ r
-        case @settings['url_pattern']
-        when 'query'
-          headers['Location'] += if headers['Location'] =~ /\?/
-                                   '&'
-                                 else
-                                   '?'
-                                 end
-          headers['Location'] += "#{@settings['lang_param_name']}=#{lang_code}"
-        when 'subdomain'
-          headers['Location'] = headers['Location'].sub(/\/\/([^.]+)/, '//' + lang_code + '.\1')
-        # when 'path'
-        else
-          headers['Location'] = headers['Location'].sub(/(\/\/[^\/]+)/, '\1/' + lang_code)
+        unless @settings['ignore_globs'].ignore?(headers['Location'])
+          case @settings['url_pattern']
+          when 'query'
+            headers['Location'] += if headers['Location'] =~ /\?/
+                                     '&'
+                                   else
+                                     '?'
+                                   end
+            headers['Location'] += "#{@settings['lang_param_name']}=#{lang_code}"
+          when 'subdomain'
+            headers['Location'] = headers['Location'].sub(/\/\/([^.]+)/, '//' + lang_code + '.\1')
+          # when 'path'
+          else
+            headers['Location'] = headers['Location'].sub(/(\/\/[^\/]+)/, '\1/' + lang_code)
+          end
         end
       end
       headers

--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -39,7 +39,6 @@ module Wovnrb
               else
                 @env['HTTP_HOST']
               end
-      @env['wovnrb.target_lang'] = lang_code
       @host = settings['url_pattern'] == 'subdomain' ? remove_lang(@host, lang_code) : @host
       @pathname, @query = @env['REQUEST_URI'].split('?')
       @pathname = settings['url_pattern'] == 'path' ? remove_lang(@pathname, lang_code) : @pathname
@@ -149,6 +148,7 @@ module Wovnrb
     end
 
     def request_out(_def_lang = @settings['default_lang'])
+      @env['wovnrb.target_lang'] = lang_code
       case @settings['url_pattern']
       when 'query'
         @env['REQUEST_URI'] = remove_lang(@env['REQUEST_URI']) if @env.key?('REQUEST_URI')

--- a/lib/wovnrb/settings.rb
+++ b/lib/wovnrb/settings.rb
@@ -7,7 +7,7 @@ module Wovnrb
 
     def [](key)
       return @dynamic_settings[key] if @dynamic_settings.key?(key)
-      return ignore_globs if key == 'ignore_globs'
+      return IgnoreGlobsWrapper.new(ignore_globs) if key == 'ignore_globs'
 
       super(key)
     end
@@ -35,5 +35,13 @@ module Wovnrb
       'wovn_token' => 'project_token',
       'wovn_ignore_paths' => 'ignore_paths'
     }.freeze
+
+    class IgnoreGlobsWrapper < Array
+      def ignore?(uri)
+        path = Addressable::URI.parse(uri).path
+
+        any? { |glob| glob.match?(path) }
+      end
+    end
   end
 end

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '2.2.0'.freeze
+  VERSION = '2.2.1'.freeze
 end

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -162,6 +162,24 @@ HTML
     assert_call_affects_env(settings, env, false, true)
   end
 
+  def test_call_changes_environment_for_next_stack_call_with_path_ignored_without_language_code_in_original_language
+    settings = {
+      'project_token' => '123456',
+      'url_pattern' => 'path',
+      'default_lang' => 'ja',
+      'supported_langs' => ['ja', 'en'],
+      'ignore_paths' => ['/ignored']
+    }
+    env = {
+      'rack.input' => '',
+      'HTTP_HOST' => 'test.com',
+      'REQUEST_URI' => '/ignored',
+      'PATH_INFO' => '/ignored'
+    }
+
+    assert_call_affects_env(settings, env, false, true)
+  end
+
   def test_call_does_not_change_environment_for_next_stack_call_with_path_ignored
     settings = {
       'project_token' => '123456',

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -113,7 +113,7 @@ HTML
       'project_token' => '123456',
       'url_pattern' => 'path',
       'default_lang' => 'ja',
-      'supported_langs' => ['ja', 'en'],
+      'supported_langs' => %w[ja en],
       'ignore_paths' => ['/en/ignored']
     }
     env = {
@@ -123,7 +123,7 @@ HTML
       'PATH_INFO' => '/en/not_ignored'
     }
 
-    assert_call_affects_env(settings, env, true, true)
+    assert_call_affects_env(settings, env, mock_api: true, affected: true)
   end
 
   def test_call_changes_environment_for_next_stack_call_with_path_ignored_with_language_code
@@ -131,7 +131,7 @@ HTML
       'project_token' => '123456',
       'url_pattern' => 'path',
       'default_lang' => 'ja',
-      'supported_langs' => ['ja', 'en'],
+      'supported_langs' => %w[ja en],
       'ignore_paths' => ['/en/ignored']
     }
     env = {
@@ -141,7 +141,7 @@ HTML
       'PATH_INFO' => '/ignored'
     }
 
-    assert_call_affects_env(settings, env, false, true)
+    assert_call_affects_env(settings, env, mock_api: false, affected: true)
   end
 
   def test_call_changes_environment_for_next_stack_call_with_path_ignored_without_language_code
@@ -149,7 +149,7 @@ HTML
       'project_token' => '123456',
       'url_pattern' => 'path',
       'default_lang' => 'ja',
-      'supported_langs' => ['ja', 'en'],
+      'supported_langs' => %w[ja en],
       'ignore_paths' => ['/ignored']
     }
     env = {
@@ -159,7 +159,7 @@ HTML
       'PATH_INFO' => '/en/ignored'
     }
 
-    assert_call_affects_env(settings, env, false, true)
+    assert_call_affects_env(settings, env, mock_api: false, affected: true)
   end
 
   def test_call_changes_environment_for_next_stack_call_with_path_ignored_without_language_code_in_original_language
@@ -167,7 +167,7 @@ HTML
       'project_token' => '123456',
       'url_pattern' => 'path',
       'default_lang' => 'ja',
-      'supported_langs' => ['ja', 'en'],
+      'supported_langs' => %w[ja en],
       'ignore_paths' => ['/ignored']
     }
     env = {
@@ -177,7 +177,7 @@ HTML
       'PATH_INFO' => '/ignored'
     }
 
-    assert_call_affects_env(settings, env, false, true)
+    assert_call_affects_env(settings, env, mock_api: false, affected: true)
   end
 
   def test_call_does_not_change_environment_for_next_stack_call_with_path_ignored
@@ -185,7 +185,7 @@ HTML
       'project_token' => '123456',
       'url_pattern' => 'path',
       'default_lang' => 'ja',
-      'supported_langs' => ['ja', 'en'],
+      'supported_langs' => %w[ja en],
       'ignore_paths' => ['/en/ignored']
     }
     env = {
@@ -195,23 +195,20 @@ HTML
       'PATH_INFO' => '/en/ignored'
     }
 
-    assert_call_affects_env(settings, env, false, false)
+    assert_call_affects_env(settings, env, mock_api: false, affected: false)
   end
 
   private
 
-  def assert_call_affects_env(settings, env, mock_api, affects)
+  def assert_call_affects_env(settings, env, mock_api:, affected:)
     app_mock = get_app
     sut = Wovnrb::Interceptor.new(app_mock, settings)
     unaffected_env = env
 
-    if mock_api
-      mock_translation_api_response('', '')
-    end
-
+    mock_translation_api_response('', '') if mock_api
     sut.call(env.clone)
 
-    assert_equal(unaffected_env != app_mock.env, affects)
+    assert_equal(unaffected_env != app_mock.env, affected)
   end
 
   def assert_switch_lang(original_lang, target_lang, body, expected_body, api_expected = true)

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -108,7 +108,7 @@ HTML
     assert_switch_lang('en', 'ja', body, body, false)
   end
 
-  def test_call_changes_environment_for_next_stack_call_without_path_ignored
+  def test_call_without_path_ignored_should_change_environment
     settings = {
       'project_token' => '123456',
       'url_pattern' => 'path',
@@ -118,6 +118,8 @@ HTML
     }
     env = {
       'rack.input' => '',
+      'rack.request.query_string' => '',
+      'rack.request.query_hash' => {},
       'HTTP_HOST' => 'test.com',
       'REQUEST_URI' => '/en/not_ignored',
       'PATH_INFO' => '/en/not_ignored'
@@ -126,7 +128,7 @@ HTML
     assert_call_affects_env(settings, env, mock_api: true, affected: true)
   end
 
-  def test_call_changes_environment_for_next_stack_call_with_path_ignored_with_language_code
+  def test_call_with_path_ignored_with_language_code_should_change_environment
     settings = {
       'project_token' => '123456',
       'url_pattern' => 'path',
@@ -136,6 +138,8 @@ HTML
     }
     env = {
       'rack.input' => '',
+      'rack.request.query_string' => '',
+      'rack.request.query_hash' => {},
       'HTTP_HOST' => 'test.com',
       'REQUEST_URI' => '/ignored',
       'PATH_INFO' => '/ignored'
@@ -144,7 +148,7 @@ HTML
     assert_call_affects_env(settings, env, mock_api: false, affected: true)
   end
 
-  def test_call_changes_environment_for_next_stack_call_with_path_ignored_without_language_code
+  def test_call_with_path_ignored_without_language_code_should_change_environment
     settings = {
       'project_token' => '123456',
       'url_pattern' => 'path',
@@ -154,6 +158,8 @@ HTML
     }
     env = {
       'rack.input' => '',
+      'rack.request.query_string' => '',
+      'rack.request.query_hash' => {},
       'HTTP_HOST' => 'test.com',
       'REQUEST_URI' => '/en/ignored',
       'PATH_INFO' => '/en/ignored'
@@ -162,7 +168,7 @@ HTML
     assert_call_affects_env(settings, env, mock_api: false, affected: true)
   end
 
-  def test_call_changes_environment_for_next_stack_call_with_path_ignored_without_language_code_in_original_language
+  def test_call_with_path_ignored_without_language_code_in_original_language_should_change_environment
     settings = {
       'project_token' => '123456',
       'url_pattern' => 'path',
@@ -172,6 +178,8 @@ HTML
     }
     env = {
       'rack.input' => '',
+      'rack.request.query_string' => '',
+      'rack.request.query_hash' => {},
       'HTTP_HOST' => 'test.com',
       'REQUEST_URI' => '/ignored',
       'PATH_INFO' => '/ignored'
@@ -180,7 +188,7 @@ HTML
     assert_call_affects_env(settings, env, mock_api: false, affected: true)
   end
 
-  def test_call_does_not_change_environment_for_next_stack_call_with_path_ignored
+  def test_call_with_path_ignored_should_not_change_environment
     settings = {
       'project_token' => '123456',
       'url_pattern' => 'path',
@@ -190,6 +198,8 @@ HTML
     }
     env = {
       'rack.input' => '',
+      'rack.request.query_string' => '',
+      'rack.request.query_hash' => {},
       'HTTP_HOST' => 'test.com',
       'REQUEST_URI' => '/en/ignored',
       'PATH_INFO' => '/en/ignored'

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -108,7 +108,93 @@ HTML
     assert_switch_lang('en', 'ja', body, body, false)
   end
 
+  def test_call_changes_environment_for_next_stack_call_without_path_ignored
+    settings = {
+      'project_token' => '123456',
+      'url_pattern' => 'path',
+      'default_lang' => 'ja',
+      'supported_langs' => ['ja', 'en'],
+      'ignore_paths' => ['/en/ignored/']
+    }
+    env = {
+      'rack.input' => '',
+      'HTTP_HOST' => 'test.com',
+      'REQUEST_URI' => '/en/not_ignored/',
+      'PATH_INFO' => '/en/not_ignored/'
+    }
+
+    assert_call_affects_env(settings, env, true, true)
+  end
+
+  def test_call_changes_environment_for_next_stack_call_with_path_ignored_with_language_code
+    settings = {
+      'project_token' => '123456',
+      'url_pattern' => 'path',
+      'default_lang' => 'ja',
+      'supported_langs' => ['ja', 'en'],
+      'ignore_paths' => ['/en/ignored/']
+    }
+    env = {
+      'rack.input' => '',
+      'HTTP_HOST' => 'test.com',
+      'REQUEST_URI' => '/ignored/',
+      'PATH_INFO' => '/ignored/'
+    }
+
+    assert_call_affects_env(settings, env, false, true)
+  end
+
+  def test_call_changes_environment_for_next_stack_call_with_path_ignored_without_language_code
+    settings = {
+      'project_token' => '123456',
+      'url_pattern' => 'path',
+      'default_lang' => 'ja',
+      'supported_langs' => ['ja', 'en'],
+      'ignore_paths' => ['/ignored/']
+    }
+    env = {
+      'rack.input' => '',
+      'HTTP_HOST' => 'test.com',
+      'REQUEST_URI' => '/en/ignored/',
+      'PATH_INFO' => '/en/ignored/'
+    }
+
+    assert_call_affects_env(settings, env, true, true)
+  end
+
+  def test_call_does_not_change_environment_for_next_stack_call_with_path_ignored
+    settings = {
+      'project_token' => '123456',
+      'url_pattern' => 'path',
+      'default_lang' => 'ja',
+      'supported_langs' => ['ja', 'en'],
+      'ignore_paths' => ['/en/ignored/']
+    }
+    env = {
+      'rack.input' => '',
+      'HTTP_HOST' => 'test.com',
+      'REQUEST_URI' => '/en/ignored/',
+      'PATH_INFO' => '/en/ignored/'
+    }
+
+    assert_call_affects_env(settings, env, false, false)
+  end
+
   private
+
+  def assert_call_affects_env(settings, env, mock_api, affects)
+    app_mock = get_app
+    sut = Wovnrb::Interceptor.new(app_mock, settings)
+    unaffected_env = env
+
+    if mock_api
+      mock_translation_api_response('', '')
+    end
+
+    sut.call(env.clone)
+
+    assert_equal(unaffected_env != app_mock.env, affects)
+  end
 
   def assert_switch_lang(original_lang, target_lang, body, expected_body, api_expected = true)
     subdomain = target_lang == original_lang ? '' : "#{target_lang}."
@@ -160,7 +246,7 @@ HTML
   end
 
   class RackMock
-    attr_accessor :params
+    attr_accessor :params, :env
 
     def initialize(opts = {})
       @params = {}

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -114,13 +114,13 @@ HTML
       'url_pattern' => 'path',
       'default_lang' => 'ja',
       'supported_langs' => ['ja', 'en'],
-      'ignore_paths' => ['/en/ignored/']
+      'ignore_paths' => ['/en/ignored']
     }
     env = {
       'rack.input' => '',
       'HTTP_HOST' => 'test.com',
-      'REQUEST_URI' => '/en/not_ignored/',
-      'PATH_INFO' => '/en/not_ignored/'
+      'REQUEST_URI' => '/en/not_ignored',
+      'PATH_INFO' => '/en/not_ignored'
     }
 
     assert_call_affects_env(settings, env, true, true)
@@ -132,13 +132,13 @@ HTML
       'url_pattern' => 'path',
       'default_lang' => 'ja',
       'supported_langs' => ['ja', 'en'],
-      'ignore_paths' => ['/en/ignored/']
+      'ignore_paths' => ['/en/ignored']
     }
     env = {
       'rack.input' => '',
       'HTTP_HOST' => 'test.com',
-      'REQUEST_URI' => '/ignored/',
-      'PATH_INFO' => '/ignored/'
+      'REQUEST_URI' => '/ignored',
+      'PATH_INFO' => '/ignored'
     }
 
     assert_call_affects_env(settings, env, false, true)
@@ -150,16 +150,16 @@ HTML
       'url_pattern' => 'path',
       'default_lang' => 'ja',
       'supported_langs' => ['ja', 'en'],
-      'ignore_paths' => ['/ignored/']
+      'ignore_paths' => ['/ignored']
     }
     env = {
       'rack.input' => '',
       'HTTP_HOST' => 'test.com',
-      'REQUEST_URI' => '/en/ignored/',
-      'PATH_INFO' => '/en/ignored/'
+      'REQUEST_URI' => '/en/ignored',
+      'PATH_INFO' => '/en/ignored'
     }
 
-    assert_call_affects_env(settings, env, true, true)
+    assert_call_affects_env(settings, env, false, true)
   end
 
   def test_call_does_not_change_environment_for_next_stack_call_with_path_ignored
@@ -168,13 +168,13 @@ HTML
       'url_pattern' => 'path',
       'default_lang' => 'ja',
       'supported_langs' => ['ja', 'en'],
-      'ignore_paths' => ['/en/ignored/']
+      'ignore_paths' => ['/en/ignored']
     }
     env = {
       'rack.input' => '',
       'HTTP_HOST' => 'test.com',
-      'REQUEST_URI' => '/en/ignored/',
-      'PATH_INFO' => '/en/ignored/'
+      'REQUEST_URI' => '/en/ignored',
+      'PATH_INFO' => '/en/ignored'
     }
 
     assert_call_affects_env(settings, env, false, false)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,7 +59,8 @@ module Wovnrb
   end
 
   def get_settings(options = {})
-    settings = {}
+    settings = Wovnrb::Store.default_settings
+
     settings['project_token'] = 'OHYx9'
     settings['url_pattern'] = 'path'
     settings['url_pattern_reg'] = '/(?<lang>[^/.?]+)'
@@ -68,7 +69,8 @@ module Wovnrb
     settings['api_url'] = 'http://localhost/v0/values'
     settings['default_lang'] = 'en'
     settings['supported_langs'] = %w[en ja]
-    settings.merge(options)
+
+    Wovnrb::Settings.new.merge(settings.merge(options))
   end
 
   def get_env(options = {})


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue 18590)
Fully ignore paths that exist with (not added by WOVN) language code

### Comments
If user set an ignore path with a language code, WOVN.rb assume it is a genuine path and does nothing.