### PR TITLE
Allow for Placing Rack Middleware before WOVN.rb Middleware on Rails

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -24,6 +24,8 @@ module Wovnrb
     end
 
     def call(env)
+      return @app.call(env) if Rack::Request.new(env).params['wovn_disable'] == true
+
       @store.settings.clear_dynamic_settings!
       return @app.call(env) unless Store.instance.valid_settings?
 

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -24,6 +24,7 @@ module Wovnrb
     end
 
     def call(env)
+      # disabled by previous Rack middleware
       return @app.call(env) if Rack::Request.new(env).params['wovn_disable'] == true
 
       @store.settings.clear_dynamic_settings!
@@ -42,6 +43,7 @@ module Wovnrb
       # pass to application
       status, res_headers, body = @app.call(headers.request_out)
 
+      # disabled by next Rack middleware
       return output(headers, status, res_headers, body) unless res_headers['Content-Type'] =~ /html/
 
       request = Rack::Request.new(env)

--- a/lib/wovnrb/railtie.rb
+++ b/lib/wovnrb/railtie.rb
@@ -1,7 +1,9 @@
 module Wovnrb
   class Railtie < Rails::Railtie
     initializer 'wovnrb.configure_rails_initialization' do |app|
-      app.middleware.insert_before(0, Wovnrb::Interceptor)
+      previous_middleware = app.config.wovnrb.symbolize_keys[:previous_middleware] || 0
+
+      app.middleware.insert_before(previous_middleware, Wovnrb::Interceptor)
       # begin
       #  app.middleware.insert_before(Rack::Runtime, Wovnrb::Interceptor)
       # rescue

--- a/lib/wovnrb/railtie.rb
+++ b/lib/wovnrb/railtie.rb
@@ -1,20 +1,17 @@
 module Wovnrb
+  def self.middleware_inserted?(app)
+    app.middleware.send(:operations).each do |_, middlewares, _|
+      return true if middlewares.include?(Wovnrb::Interceptor)
+    end
+
+    false
+  end
+
   class Railtie < Rails::Railtie
     initializer 'wovnrb.configure_rails_initialization' do |app|
-      previous_middleware = app.config.wovnrb.symbolize_keys[:previous_middleware] || 0
-
-      app.middleware.insert_before(previous_middleware, Wovnrb::Interceptor)
-      # begin
-      #  app.middleware.insert_before(Rack::Runtime, Wovnrb::Interceptor)
-      # rescue
-      #  app.middleware.insert_before(0, Wovnrb::Interceptor)
-      # end
-
-      # if Rails.env.development? && config.respond_to?(:wovnrb)
-      #  config.after_initialize do
-      #    config.wovnrb[:project_token] = User.first.short_token
-      #  end
-      # end
+      unless Wovnrb.middleware_inserted?(app)
+        app.middleware.insert_before(0, Wovnrb::Interceptor)
+      end
     end
   end
 end

--- a/lib/wovnrb/railtie.rb
+++ b/lib/wovnrb/railtie.rb
@@ -9,9 +9,7 @@ module Wovnrb
 
   class Railtie < Rails::Railtie
     initializer 'wovnrb.configure_rails_initialization' do |app|
-      unless Wovnrb.middleware_inserted?(app)
-        app.middleware.insert_before(0, Wovnrb::Interceptor)
-      end
+      app.middleware.insert_before(0, Wovnrb::Interceptor) unless Wovnrb.middleware_inserted?(app)
     end
   end
 end


### PR DESCRIPTION
### Purpose/goal of Pull Request
Allow Rails user to add middleware before WOVN.rb middleware for a better control of WOVN.rb. For instance, having custom middleware called before WOVN.rb will allow from disabling WOVN.rb before any environment alterations are performed by WOVN.rb (WOVN.rb remove language specific information from environment sent to next middlewares).

By default behavior remains same. If user does not add WOVN.rb middleware themselves, then WOVN.rb railtie will insert the middleware on top of the stack.

### Comments
Following is a Rails setup example.
`config/application.rb`
```
class TestMiddleware
  def initialize(app)
    @app = app
  end

  def call(env)
    Rack::Request.new(env).update_param('wovn_disable', true)
    return @app.call(env)
  end
end

module MyApp
  class Application < Rails::Application
    # ...
    config.middleware.insert_before(0, TestMiddleware)
    config.middleware.insert_after(TestMiddleware, Wovnrb::Interceptor)
    # ...
  end
end
```