### PR TITLE
[IS-376] Add support for `lang_param_name`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -101,6 +101,8 @@ Metrics/BlockNesting:
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Max: 4997
+  Exclude:
+    - 'test/lib/headers_test.rb'
 
 # Offense count: 14
 Metrics/CyclomaticComplexity:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ project_token      | yes      | ''
 default_lang       | yes      | 'en'
 supported_langs    | yes      | ['en']
 url_pattern        | yes      | 'path'
-lang_param_anme    |          | 'wovn'
+lang_param_name    |          | 'wovn'
 query              |          | []
 ignore_class       |          | []
 translate_fragment |          | true

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ project_token      | yes      | ''
 default_lang       | yes      | 'en'
 supported_langs    | yes      | ['en']
 url_pattern        | yes      | 'path'
+lang_param_anme    |          | 'wovn'
 query              |          | []
 ignore_class       |          | []
 translate_fragment |          | true
@@ -126,7 +127,17 @@ parameters  | Translated page's URL           | Notes
 
 	https://wovn.io/contact
 
-### 2.5. query
+### 2.5 lang_param_name
+This parameter is only valid for when `url_pattern_name` is set to `'query'`.
+
+It allows you to set the query parameter name for declaring the language of the
+page. The default value for this setting is `'wovn'`, such that a page URL in
+translated language English has the form
+`https://my-website.com/index.php?wovn=en`. If you instead set the value to
+`'lang'`, then the later URL example would have the form
+`https://my-website.com/index.php?lang=en`.
+
+### 2.6. query
 
 WOVN.io ignores query parameters when searching a translated page. If you want to add a query parameter to translated page's URL, you should configure the `query` parameter. (You need to configure WOVN.io too)
 
@@ -140,11 +151,11 @@ If the `default_lang` is 'en', and the query is set to 'os', the above URL will 
 
 	https://wovn.io/contact?os=mac
 
-### 2.6. ignore_class
+### 2.7. ignore_class
 
 This sets "Ignore class" which prevents WOVN from translating HTML elements that have a class contained in this array.
 
-### 2.7. translate_fragment
+### 2.8. translate_fragment
 
 This option allows to disable translating partial HTML content. By default,
 partial HTML content is translated but no widget snippet is added. Set

--- a/lib/wovnrb/api_translator.rb
+++ b/lib/wovnrb/api_translator.rb
@@ -87,6 +87,7 @@ module Wovnrb
         'token' => token,
         'lang_code' => lang_code,
         'url_pattern' => url_pattern,
+        'lang_param_name' => lang_param_name,
         'product' => 'WOVN.rb',
         'version' => VERSION,
         'body' => body
@@ -129,6 +130,10 @@ module Wovnrb
 
     def url_pattern
       @store.settings['url_pattern']
+    end
+
+    def lang_param_name
+      @store.settings['lang_param_name']
     end
 
     def custom_lang_aliases

--- a/lib/wovnrb/headers.rb
+++ b/lib/wovnrb/headers.rb
@@ -133,10 +133,11 @@ module Wovnrb
         location = url
         case @settings['url_pattern']
         when 'query'
+          lang_param_name = @settings['lang_param_name']
           if location !~ /\?/
-            location = "#{location}?wovn=#{lang_code}"
-          else @env['REQUEST_URI'] !~ /(\?|&)wovn=/
-               location = "#{location}&wovn=#{lang_code}"
+            location = "#{location}?#{lang_param_name}=#{lang_code}"
+          else @env['REQUEST_URI'] !~ /(\?|&)#{lang_param_name}=/
+               location = "#{location}&#{lang_param_name}=#{lang_code}"
           end
         when 'subdomain'
           location = "#{lang_code.downcase}.#{location}"
@@ -187,7 +188,8 @@ module Wovnrb
 
       case @settings['url_pattern']
       when 'query'
-        return uri.sub(/(^|\?|&)wovn=#{lang_code}(&|$)/, '\1').gsub(/(\?|&)$/, '')
+        lang_param_name = @settings['lang_param_name']
+        return uri.sub(/(^|\?|&)#{lang_param_name}=#{lang_code}(&|$)/, '\1').gsub(/(\?|&)$/, '')
       when 'subdomain'
         rp = Regexp.new('(^|(//))' + lang_code + '\.', 'i')
         return uri.sub(rp, '\1')
@@ -208,7 +210,7 @@ module Wovnrb
                                  else
                                    '?'
                                  end
-          headers['Location'] += "wovn=#{lang_code}"
+          headers['Location'] += "#{@settings['lang_param_name']}=#{lang_code}"
         when 'subdomain'
           headers['Location'] = headers['Location'].sub(/\/\/([^.]+)/, '//' + lang_code + '.\1')
         # when 'path'

--- a/lib/wovnrb/lang.rb
+++ b/lib/wovnrb/lang.rb
@@ -91,7 +91,9 @@ module Wovnrb
     def add_lang_code(href, pattern, headers)
       return href if href =~ /^(#.*)?$/
 
-      code_to_add = Store.instance.settings['custom_lang_aliases'][@lang_code] || @lang_code
+      settings = Store.instance.settings
+      code_to_add = settings['custom_lang_aliases'][@lang_code] || @lang_code
+      lang_param_name = settings['lang_param_name']
       # absolute links
       new_href = href
       if href && href =~ /^(https?:)?\/\//i
@@ -115,7 +117,7 @@ module Wovnrb
                          href.sub(/(\/\/)([^\.]*)/, '\1' + code_to_add.downcase + '.' + '\2')
                        end
           when 'query'
-            new_href = add_query_lang_code(href, code_to_add)
+            new_href = add_query_lang_code(href, code_to_add, lang_param_name)
           else # path
             new_href = href.sub(/([^\.]*\.[^\/]*)(\/|$)/, '\1/' + code_to_add + '/')
           end
@@ -139,7 +141,7 @@ module Wovnrb
                        lang_url + current_dir + '/' + href
                      end
         when 'query'
-          new_href = add_query_lang_code(href, code_to_add)
+          new_href = add_query_lang_code(href, code_to_add, lang_param_name)
         else # path
           if href =~ /^\//
             new_href = '/' + code_to_add + href
@@ -209,10 +211,10 @@ module Wovnrb
       langs
     end
 
-    def add_query_lang_code(href, lang_code)
+    def add_query_lang_code(href, lang_code, lang_param_name)
       query_separator = href =~ /\?/ ? '&' : '?'
 
-      href.sub(/(#|$)/, "#{query_separator}wovn=#{lang_code}\\1")
+      href.sub(/(#|$)/, "#{query_separator}#{lang_param_name}=#{lang_code}\\1")
     end
   end
 end

--- a/lib/wovnrb/services/html_converter.rb
+++ b/lib/wovnrb/services/html_converter.rb
@@ -176,6 +176,7 @@ module Wovnrb
       default_lang = @store.settings['default_lang']
       url_pattern = @store.settings['url_pattern']
       lang_code_aliases_json = JSON.generate(@store.settings['custom_lang_aliases'])
+      lang_param_name = @store.settings['lang_param_name']
 
       [
         "key=#{token}",
@@ -184,6 +185,7 @@ module Wovnrb
         "defaultLang=#{default_lang}",
         "urlPattern=#{url_pattern}",
         "langCodeAliases=#{lang_code_aliases_json}",
+        "langParamName=#{lang_param_name}",
         "version=WOVN.rb_#{VERSION}"
       ].join('&')
     end

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -144,7 +144,7 @@ module Wovnrb
       if @settings['url_pattern'] == 'path'
         @settings['url_pattern_reg'] = "/(?<lang>[^/.?]+)"
       elsif @settings['url_pattern'] == 'query'
-        @settings['url_pattern_reg'] = "((\\?.*&)|\\?)wovn=(?<lang>[^&]+)(&|$)"
+        @settings['url_pattern_reg'] = "((\\?.*&)|\\?)#{@settings['lang_param_name']}=(?<lang>[^&]+)(&|$)"
       elsif @settings['url_pattern'] == 'subdomain'
         @settings['url_pattern_reg'] = "^(?<lang>[^.]+)\."
       end

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -20,6 +20,7 @@ module Wovnrb
         'ignore_globs' => [],
         'url_pattern' => 'path',
         'url_pattern_reg' => "/(?<lang>[^/.?]+)",
+        'lang_param_name' => 'wovn',
         'query' => [],
         'ignore_class' => [],
         'api_url' => 'https://wovn.global.ssl.fastly.net/v0/',

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -44,7 +44,8 @@ module Wovnrb
         'custom_lang_aliases' => { 'ja' => 'Japanese' },
         'default_lang' => 'en',
         'url_pattern' => 'subdomain',
-        'url_pattern_reg' => '^(?<lang>[^.]+).'
+        'url_pattern_reg' => '^(?<lang>[^.]+).',
+        'lang_param_name' => 'lang'
       }
       store = Wovnrb::Store.instance
       store.update_settings(settings)
@@ -106,6 +107,7 @@ module Wovnrb
         'token' => '123456',
         'lang_code' => 'fr',
         'url_pattern' => 'subdomain',
+        'lang_param_name' => 'lang',
         'product' => 'WOVN.rb',
         'version' => VERSION,
         'body' => original_html,

--- a/test/lib/headers_test.rb
+++ b/test/lib/headers_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module Wovnrb
-  class LangTest < WovnMiniTest
+  class HeadersTest < WovnMiniTest
     #########################
     # INITIALIZE
     #########################
@@ -151,13 +151,31 @@ module Wovnrb
       assert_equal('http://ja.wovn.io/contact', h.redirect_location('ja'))
     end
 
-    def test_redirect_location_without_custom_lang_code
+    def test_redirect_location_with_custom_lang_code
       Store.instance.update_settings('custom_lang_aliases' => { 'ja' => 'staging-ja' })
       h = Wovnrb::Headers.new(
         Wovnrb.get_env('url' => 'http://wovn.io/contact', 'HTTP_X_FORWARDED_HOST' => 'wovn.io'),
         Wovnrb.get_settings('url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).')
       )
       assert_equal('http://staging-ja.wovn.io/contact', h.redirect_location('ja'))
+    end
+
+    def test_redirect_location_without_lang_param_name
+      Store.instance.update_settings('url_pattern' => 'query')
+      sut = Wovnrb::Headers.new(
+        Wovnrb.get_env('url' => 'http://wovn.io/contact', 'HTTP_X_FORWARDED_HOST' => 'wovn.io'),
+        Store.instance.settings
+      )
+      assert_equal('http://wovn.io/contact?wovn=ja', sut.redirect_location('ja'))
+    end
+
+    def test_redirect_location_with_lang_param_name
+      Store.instance.update_settings('url_pattern' => 'query', 'lang_param_name' => 'lang')
+      sut = Wovnrb::Headers.new(
+        Wovnrb.get_env('url' => 'http://wovn.io/contact', 'HTTP_X_FORWARDED_HOST' => 'wovn.io'),
+        Store.instance.settings
+      )
+      assert_equal('http://wovn.io/contact?lang=ja', sut.redirect_location('ja'))
     end
 
     #########################
@@ -368,6 +386,17 @@ module Wovnrb
         )
       )
       headers = h.out(h.request_out('ja'))
+      assert_equal('ja', headers['wovnrb.target_lang'])
+    end
+
+    def test_out_with_wovn_target_lang_header_using_query_with_lang_param_name
+      Store.instance.update_settings('url_pattern' => 'query', 'lang_param_name' => 'lang')
+      sut = Wovnrb::Headers.new(
+        Wovnrb.get_env('REQUEST_URI' => 'test?lang=ja', 'HTTP_REFERER' => 'http://wovn.io/test'),
+        Store.instance.settings
+      )
+      headers = sut.out(sut.request_out('ja'))
+
       assert_equal('ja', headers['wovnrb.target_lang'])
     end
 
@@ -6182,6 +6211,25 @@ module Wovnrb
         assert_equal('wovn.io/', uri_without_scheme)
 
         uri_with_scheme = h.remove_lang("https://wovn.io?wovn=#{key}", key)
+        assert_equal('https://wovn.io', uri_with_scheme)
+      end
+    end
+
+    def test_remove_lang_query_with_lang_param_name
+      sut = Wovnrb::Headers.new(Wovnrb.get_env, Wovnrb.get_settings('url_pattern' => 'query', 'lang_param_name' => 'lang'))
+
+      keys = Wovnrb::Lang::LANG.keys
+      assert_equal(39, keys.size)
+
+      for key in keys
+        uri_without_custom_lang_param = "wovn.io/?wovn=#{key}"
+        unchanged_uri = sut.remove_lang(uri_without_custom_lang_param, key)
+        assert_equal(uri_without_custom_lang_param, unchanged_uri)
+
+        uri_without_scheme = sut.remove_lang("wovn.io/?lang=#{key}", key)
+        assert_equal('wovn.io/', uri_without_scheme)
+
+        uri_with_scheme = sut.remove_lang("https://wovn.io?lang=#{key}", key)
         assert_equal('https://wovn.io', uri_with_scheme)
       end
     end

--- a/test/lib/lang_test.rb
+++ b/test/lib/lang_test.rb
@@ -233,6 +233,18 @@ module Wovnrb
       assert_equal('http://fr.home.google.com', lang.add_lang_code('http://home.google.com', 'subdomain', headers))
     end
 
+    def test_add_lang_code_with_query_and_lang_param_name
+      Store.instance.update_settings('url_pattern_name' => 'query', 'lang_param_name' => 'lang')
+
+      sut = Lang.new('fr')
+      headers = Wovnrb::Headers.new(
+        Wovnrb.get_env('url' => 'http://google.com'),
+        Store.instance.settings
+      )
+
+      assert_equal('http://google.com?hey=yo&lang=fr', sut.add_lang_code('http://google.com?hey=yo', 'query', headers))
+    end
+
     def test_add_lang_code_absolute_query_no_query
       lang = Lang.new('fr')
       headers = Wovnrb::Headers.new(Wovnrb.get_env('url' => 'http://google.com'), Wovnrb.get_settings)

--- a/test/lib/services/html_converter_test.rb
+++ b/test/lib/services/html_converter_test.rb
@@ -6,7 +6,15 @@ module Wovnrb
       converter = prepare_html_converter('<html><body><a class="test">hello</a></body></html>', supported_langs: %w[en vi])
       converted_html, = converter.build_api_compatible_html
 
-      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a class=\"test\">hello</a></body></html>"
+      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a class=\"test\">hello</a></body></html>"
+      assert_equal(expected_html, converted_html)
+    end
+
+    def test_build_api_compatible_html_with_custom_lang_param_name
+      converter = prepare_html_converter('<html><body><a class="test">hello</a></body></html>', supported_langs: %w[en vi], lang_param_name: 'lang')
+      converted_html, = converter.build_api_compatible_html
+
+      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=lang&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a class=\"test\">hello</a></body></html>"
       assert_equal(expected_html, converted_html)
     end
 
@@ -15,7 +23,7 @@ module Wovnrb
       converter = prepare_html_converter('<html><body><p>' + long_string + '</p></body></html>', supported_langs: %w[en vi])
       converted_html, = converter.build_api_compatible_html
 
-      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><p>" + long_string + '</p></body></html>'
+      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><p>" + long_string + '</p></body></html>'
       assert_equal(expected_html, converted_html)
     end
 
@@ -31,7 +39,7 @@ module Wovnrb
       converter = prepare_html_converter(html, ignore_class: ['ignore-me'])
       converted_html, = converter.build_api_compatible_html
 
-      expected_convert_html = "<html><head><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><p>Hello <span wovn-ignore=\"\"><!-- __wovn-backend-ignored-key-0 --></span></p><p></p><div><span class=\"ignore-me\"><!-- __wovn-backend-ignored-key-1 --></span></div><span>Have a nice day!</span></body></html>"
+      expected_convert_html = "<html><head><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><p>Hello <span wovn-ignore=\"\"><!-- __wovn-backend-ignored-key-0 --></span></p><p></p><div><span class=\"ignore-me\"><!-- __wovn-backend-ignored-key-1 --></span></div><span>Have a nice day!</span></body></html>"
       assert_equal(expected_convert_html, converted_html)
     end
 
@@ -48,7 +56,7 @@ module Wovnrb
       converter = prepare_html_converter(html, ignore_class: [])
       converted_html, = converter.build_api_compatible_html
 
-      expected_convert_html = "<html><head><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><form action=\"/test\" method=\"POST\"><!-- __wovn-backend-ignored-key-0 --></form></body></html>"
+      expected_convert_html = "<html><head><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><form action=\"/test\" method=\"POST\"><!-- __wovn-backend-ignored-key-0 --></form></body></html>"
       assert_equal(expected_convert_html, converted_html)
     end
 
@@ -63,7 +71,7 @@ module Wovnrb
       converter = prepare_html_converter(html, ignore_class: [])
       converted_html, = converter.build_api_compatible_html
 
-      expected_convert_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><input id=\"user-id\" type=\"hidden\" value=\"<!-- __wovn-backend-ignored-key-0 -->\"><input id=\"name\" type=\"text\" value=\"wovn.io\"></body></html>"
+      expected_convert_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><input id=\"user-id\" type=\"hidden\" value=\"<!-- __wovn-backend-ignored-key-0 -->\"><input id=\"name\" type=\"text\" value=\"wovn.io\"></body></html>"
       assert_equal(expected_convert_html, converted_html)
     end
 
@@ -71,7 +79,7 @@ module Wovnrb
       converter = prepare_html_converter('<html><body><a>hello</a></body></html>', supported_langs: %w[en vi])
       translated_html = converter.build
 
-      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"
+      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -79,7 +87,7 @@ module Wovnrb
       converter = prepare_html_converter('<html><body><a>hello</a></body></html>', supported_langs: [])
       translated_html = converter.build
 
-      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body><a>hello</a></body></html>"
+      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body><a>hello</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -87,7 +95,7 @@ module Wovnrb
       converter = prepare_html_converter('<html><head><title>TITLE</title></head><body><a>hello</a></body></html>', supported_langs: %w[en vi])
       translated_html = converter.build
 
-      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><title>TITLE</title><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"
+      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><title>TITLE</title><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -95,7 +103,7 @@ module Wovnrb
       converter = prepare_html_converter('<html>hello<a>world</a></html>', supported_langs: [])
       translated_html = converter.build
 
-      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body>hello<a>world</a></body></html>"
+      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body>hello<a>world</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -110,7 +118,7 @@ module Wovnrb
       converter = HtmlConverter.new(dom, store, headers)
       translated_html = converter.build
 
-      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body>hello<a>world</a></body></html>"
+      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body>hello<a>world</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -125,7 +133,7 @@ module Wovnrb
       converter = HtmlConverter.new(dom, store, headers)
       translated_html = converter.build
 
-      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/ja/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/vi/\"></head><body>hello<a>world</a></body></html>"
+      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/ja/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/vi/\"></head><body>hello<a>world</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -133,7 +141,7 @@ module Wovnrb
       converter = prepare_html_converter('<html><head><script src="/a"></script><script src="//j.wovn.io/1" async="true"</head></html>')
       converter.send(:replace_snippet)
 
-      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><script src=\"/a\"></script></head><body></body></html>"
+      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><script src=\"/a\"></script></head><body></body></html>"
       assert_equal(expected_html, converter.send(:html))
     end
 

--- a/test/lib/services/html_converter_test.rb
+++ b/test/lib/services/html_converter_test.rb
@@ -11,10 +11,15 @@ module Wovnrb
     end
 
     def test_build_api_compatible_html_with_custom_lang_param_name
-      converter = prepare_html_converter('<html><body><a class="test">hello</a></body></html>', supported_langs: %w[en vi], lang_param_name: 'lang')
+      settings = {
+        supported_langs: %w[en vi],
+        url_lang_pattern: 'query',
+        lang_param_name: 'lang'
+      }
+      converter = prepare_html_converter('<html><body><a class="test">hello</a></body></html>', settings)
       converted_html, = converter.build_api_compatible_html
 
-      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=lang&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a class=\"test\">hello</a></body></html>"
+      expected_html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"//j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=lang&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?lang=vi\"></head><body><a class=\"test\">hello</a></body></html>"
       assert_equal(expected_html, converted_html)
     end
 
@@ -182,7 +187,7 @@ module Wovnrb
 
       headers = Wovnrb::Headers.new(
         Wovnrb.get_env('url' => 'http://my-site.com'),
-        Wovnrb.get_settings(settings)
+        store.settings
       )
 
       [store, headers]

--- a/test/lib/store_test.rb
+++ b/test/lib/store_test.rb
@@ -55,6 +55,19 @@ module Wovnrb
       assert_equal('query', s.settings['url_pattern'])
     end
 
+    def test_lang_param_name_wovn_by_default
+      sut = Wovnrb::Store.instance
+
+      assert_equal('wovn', sut.settings['lang_param_name'])
+    end
+
+    def test_lang_param_name_update
+      sut = Wovnrb::Store.instance
+
+      sut.update_settings('lang_param_name' => 'lang')
+      assert_equal('lang', sut.settings['lang_param_name'])
+    end
+
     def test_invalid_settings
       mock = LogMock.mock_log
       store = Wovnrb::Store.instance

--- a/test/lib/store_test.rb
+++ b/test/lib/store_test.rb
@@ -55,6 +55,15 @@ module Wovnrb
       assert_equal('query', s.settings['url_pattern'])
     end
 
+    def test_settings_url_pattern_query_with_lang_param_name
+      sut = Wovnrb::Store.instance
+
+      sut.update_settings('url_pattern' => 'query', 'lang_param_name' => 'lang')
+
+      assert_equal('((\\?.*&)|\\?)lang=(?<lang>[^&]+)(&|$)', sut.settings['url_pattern_reg'])
+      assert_equal('query', sut.settings['url_pattern'])
+    end
+
     def test_lang_param_name_wovn_by_default
       sut = Wovnrb::Store.instance
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,6 +63,7 @@ module Wovnrb
     settings['project_token'] = 'OHYx9'
     settings['url_pattern'] = 'path'
     settings['url_pattern_reg'] = '/(?<lang>[^/.?]+)'
+    settings['lang_param_name'] = 'wovn'
     settings['query'] = []
     settings['api_url'] = 'http://localhost/v0/values'
     settings['default_lang'] = 'en'


### PR DESCRIPTION
### Purpose/goal of Pull Request
Add `lang_param_name` option support.

### Comments
`lang_param_name` option allows user to customize the query parameter user to store the language information when `url_pattern_name` is set to `query`. Previous, `wovn` was the only available value for the name of the query parameter to store the language information. `wovn` remains the default value for retro compatibility.