### PR TITLE
Add Rack::Deflater Support in railtie.rb

### DIFF
--- a/lib/wovnrb/railtie.rb
+++ b/lib/wovnrb/railtie.rb
@@ -1,7 +1,7 @@
 module Wovnrb
-  def self.middleware_inserted?(app)
+  def self.middleware_inserted?(app, middleware)
     app.middleware.send(:operations).each do |_, middlewares, _|
-      return true if middlewares.include?(Wovnrb::Interceptor)
+      return true if middlewares.include?(middleware)
     end
 
     false
@@ -9,7 +9,13 @@ module Wovnrb
 
   class Railtie < Rails::Railtie
     initializer 'wovnrb.configure_rails_initialization' do |app|
-      app.middleware.insert_before(0, Wovnrb::Interceptor) unless Wovnrb.middleware_inserted?(app)
+      unless Wovnrb.middleware_inserted?(app, Wovnrb::Interceptor)
+        if defined?(Rack::Deflater) && Wovnrb.middleware_inserted?(app, Rack::Deflater)
+          app.middleware.insert_after(Rack::Deflater, Wovnrb::Interceptor)
+        else
+          app.middleware.insert_before(0, Wovnrb::Interceptor)
+        end
+      end
     end
   end
 end

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.2.0'.freeze
 end


### PR DESCRIPTION
### Purpose/goal of Pull Request
Ensure that interception happens before `Rack::Deflater` compression.

### Comments
`Rack::Deflater` compresses response rendering WOVN.rb inable to translate content. This change ensures that WOVN.rb middleware installs itself after `Rack::Defleter` middleware so that it can process data before `Rack::Deflater` compresses it.