### PR TITLE
Return wovn_host of `dev-wovn.io` without port in dev mode

### DIFF
--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -185,7 +185,7 @@ module Wovnrb
 
     def wovn_host
       if @settings['wovn_dev_mode']
-        'dev-wovn.io:3000'
+        'dev-wovn.io'
       else
         'wovn.io'
       end

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '2.2.5'.freeze
+  VERSION = '2.2.6'.freeze
 end

--- a/test/lib/store_test.rb
+++ b/test/lib/store_test.rb
@@ -132,6 +132,7 @@ module Wovnrb
       store.update_settings('wovn_dev_mode' => true)
 
       assert(store.dev_mode?)
+      assert_equal('dev-wovn.io', store.wovn_host)
       assert_equal('http://dev-wovn.io:3001/v0/', store.settings['api_url'])
       assert_equal(3, store.settings['api_timeout_seconds'])
     end


### PR DESCRIPTION
Because we switched to use `https` in dev mode recently
