### PR TITLE
fix: [SUP-713] temporary fix for railtie middleware check not working on newer rails

### DIFF
--- a/lib/wovnrb/railtie.rb
+++ b/lib/wovnrb/railtie.rb
@@ -1,7 +1,7 @@
 module Wovnrb
   def self.middleware_inserted?(app, middleware)
     app.middleware.send(:operations).each do |_, middlewares, _|
-      return true if middlewares.include?(middleware)
+      return true if middlewares&.include?(middleware)
     end
 
     false

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.5.1'.freeze
 end


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
https://wovnio.atlassian.net/browse/SUP-713
### Comments
We're relying on private code inside rails for checking if the middleware is installed already. But the signature of this private method changed in a newer version. This fix is just a hack to stop it crashing (so it won't behave correctly with Deflater). I will look for a better way of doing this afterwards.

https://github.com/rails/rails/commit/fedde239dcee256b417dc9bcfe5fef603bf0d952#diff-17b775617b7196b0e9851f109b0b3269d3e41a1a0893daa1832bdfb847f71477