### PR TITLE
[ST-902] Add custom_response route to test docker, allowing the tests to control the website externally.

### DIFF
--- a/docker/rails/TestSite/app/controllers/custom_response_controller.rb
+++ b/docker/rails/TestSite/app/controllers/custom_response_controller.rb
@@ -1,5 +1,5 @@
 class CustomResponseController < ApplicationController
-  skip_before_action :verify_authenticity_token
+  skip_before_action :verify_authenticity_token 
 
   def make_response
     response_args_json = params[:response]

--- a/docker/rails/TestSite/app/controllers/custom_response_controller.rb
+++ b/docker/rails/TestSite/app/controllers/custom_response_controller.rb
@@ -1,0 +1,16 @@
+class CustomResponseController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def make_response
+    response_args_json = params[:response]
+    raise ActionController::BadRequest unless response_args_json
+
+    (response_args_json[:headers] || {}).each do |name, value|
+      response.headers[name] = value
+    end
+
+    render inline: response_args_json[:body],
+           status: response_args_json[:status],
+           content_type: response_args_json[:content_type]
+  end
+end

--- a/docker/rails/TestSite/app/controllers/custom_response_controller.rb
+++ b/docker/rails/TestSite/app/controllers/custom_response_controller.rb
@@ -1,5 +1,5 @@
 class CustomResponseController < ApplicationController
-  skip_before_action :verify_authenticity_token 
+  skip_before_action :verify_authenticity_token
 
   def make_response
     response_args_json = params[:response]

--- a/docker/rails/TestSite/app/controllers/custom_response_controller.rb
+++ b/docker/rails/TestSite/app/controllers/custom_response_controller.rb
@@ -1,5 +1,5 @@
 class CustomResponseController < ApplicationController
-  skip_before_action :verify_authenticity_token
+  skip_before_action :verify_authenticity_token2
 
   def make_response
     response_args_json = params[:response]

--- a/docker/rails/TestSite/config/routes.rb
+++ b/docker/rails/TestSite/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   get "/redirecting_page" => "redirects#show"
-  get "/custom_response" => "custom_response#make_response"
+  get "/custom_response/*all" => "custom_response#make_response"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/docker/rails/TestSite/config/routes.rb
+++ b/docker/rails/TestSite/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get "/redirecting_page" => "redirects#show"
+  get "/custom_response" => "custom_response#make_response"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
https://wovnio.atlassian.net/browse/ST-902
### Comments
In the test docker website, there is now a `/custom_response` route. You can send it a request like
```
GET /custom_response

body:
{
    "response": {
        "body": "foo2",
        "content-type": "text/html",
        "status": 200,
        "headers": { "X-WovnTest": "Foo" }
    }
}
```

and it will generate the response according to these parameters. Our tests can use this to change the HTML and headers, rather than needing to add new test scenarios to the docker directly.



```
 curl --verbose --location --request GET 'http://localhost:4000/custom_response' \
> --header 'Content-Type: application/json' \
> --data-raw '{
>     "response": {
>         "body": "foo2",
>         "content-type": "text/html",
>         "status": 201,
>         "headers": { "X-WovnTest": "Foo" }
>     }
> }'
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 4000 (#0)
> GET /custom_response HTTP/1.1
> Host: localhost:4000
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 154
> 
* upload completely sent off: 154 out of 154 bytes
< HTTP/1.1 201 Created
< X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Download-Options: noopen
< X-Permitted-Cross-Domain-Policies: none
< Referrer-Policy: strict-origin-when-cross-origin
< X-WovnTest: Foo
< Content-Type: text/html; charset=utf-8
< ETag: W/"4963bd713a7eb1bce458868b0c8472bd"
< Cache-Control: max-age=0, private, must-revalidate
< X-Request-Id: 00a7d334-13d9-4255-ab7a-058bcfb933f1
< X-Runtime: 0.004903
< Content-Length: 4
< 
* Connection #0 to host localhost left intact
foo2* Closing connection 0

```