### PR TITLE
fix: set default value of install_middleware to be true

### DIFF
--- a/lib/wovnrb/railtie.rb
+++ b/lib/wovnrb/railtie.rb
@@ -1,7 +1,9 @@
 module Wovnrb
   class Railtie < Rails::Railtie
     initializer 'wovnrb.configure_rails_initialization' do |app|
-      app.middleware.insert_before(0, Wovnrb::Interceptor) if Rails.configuration.wovnrb[:install_middleware]
+      install_middleware = Rails.configuration.wovnrb.fetch(:install_middleware, true)
+
+      app.middleware.insert_before(0, Wovnrb::Interceptor) if install_middleware
     end
   end
 end

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.0.3'.freeze
 end


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)

### Comments
Forgot to set a default value in https://github.com/WOVNio/wovnrb/pull/170

When `install_middleware` is not specified in wovnrb config => true (easier for existing customers to upgrade)
When `install_middleware` is set to true or false in wovnrb config => use config value
