### PR TITLE
feature:  [ST-1100] Add compress_api_request setting, for sending uncompressed html swapper requests for testing

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -74,18 +74,19 @@ After completing setup, start the Ruby Application, and make sure the WOVN.io li
 
 The following is a list of the WOVN.io Ruby Library's valid parameters.
 
-Parameter Name     | Required | Default Setting
------------------- | -------- | ----------------
-project_token      | yes      | ''
-default_lang       | yes      | 'en'
-supported_langs    | yes      | ['en']
-url_pattern        | yes      | 'path'
-lang_param_name    |          | 'wovn'
-query              |          | []
-ignore_class       |          | []
-translate_fragment |          | true
-ignore_paths       |          | []
-install_middleware |          | true
+Parameter Name        | Required | Default Setting
+----------------------| -------- | ----------------
+project_token         | yes      | ''
+default_lang          | yes      | 'en'
+supported_langs       | yes      | ['en']
+url_pattern           | yes      | 'path'
+lang_param_name       |          | 'wovn'
+query                 |          | []
+ignore_class          |          | []
+translate_fragment    |          | true
+ignore_paths          |          | []
+install_middleware    |          | true
+compress_api_requests |          | true
 
 ### 2.1. project_token
 
@@ -196,3 +197,7 @@ WOVN.rb needs to be added after any compression middleware.
     :install_middleware => false
   }
 ```
+
+### 2.11 compress_api_requests
+
+By default, requests to the translation API will be sent with gzip compression. Set to false to disable compression.

--- a/lib/wovnrb/api_translator.rb
+++ b/lib/wovnrb/api_translator.rb
@@ -65,6 +65,7 @@ module Wovnrb
       request = Net::HTTP::Post.new(request_path(html_body), {
                                       'Accept-Encoding' => 'gzip',
                                       'Content-Type' => 'application/octet-stream',
+                                      'Content-Encoding' => 'gzip',
                                       'Content-Length' => compressed_body.bytesize.to_s,
                                       'X-Request-Id' => @uuid
                                     })

--- a/lib/wovnrb/api_translator.rb
+++ b/lib/wovnrb/api_translator.rb
@@ -52,7 +52,7 @@ module Wovnrb
     end
 
     def prepare_request(body)
-      if @store.compress_api_request?
+      if @store.compress_api_requests?
         gzip_request(body)
       else
         json_request(body)
@@ -63,11 +63,11 @@ module Wovnrb
       api_params = build_api_params(html_body)
       compressed_body = compress_request_data(api_params)
       request = Net::HTTP::Post.new(request_path(html_body), {
-        'Accept-Encoding' => 'gzip',
-        'Content-Type' => 'application/octet-stream',
-        'Content-Length' => compressed_body.bytesize.to_s,
-        'X-Request-Id' => @uuid
-      })
+                                      'Accept-Encoding' => 'gzip',
+                                      'Content-Type' => 'application/octet-stream',
+                                      'Content-Length' => compressed_body.bytesize.to_s,
+                                      'X-Request-Id' => @uuid
+                                    })
       request.body = compressed_body
 
       request
@@ -76,10 +76,10 @@ module Wovnrb
     def json_request(html_body)
       api_params = build_api_params(html_body)
       request = Net::HTTP::Post.new(request_path(html_body), {
-        'Accept-Encoding' => 'gzip',
-        'Content-Type' => 'application/json',
-        'X-Request-Id' => @uuid
-      })
+                                      'Accept-Encoding' => 'gzip',
+                                      'Content-Type' => 'application/json',
+                                      'X-Request-Id' => @uuid
+                                    })
       request.body = api_params.to_json
 
       request

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -35,7 +35,8 @@ module Wovnrb
         'custom_lang_aliases' => {},
         'translate_fragment' => true,
         'widget_url' => 'https://j.wovn.io/1',
-        'wovn_dev_mode' => false
+        'wovn_dev_mode' => false,
+        'compress_api_request' => true
       )
     end
 
@@ -179,6 +180,10 @@ module Wovnrb
 
     def supported_langs
       @settings['supported_langs'] || []
+    end
+
+    def compress_api_request?
+      @settings['compress_api_request']
     end
 
     def widget_url

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -36,7 +36,7 @@ module Wovnrb
         'translate_fragment' => true,
         'widget_url' => 'https://j.wovn.io/1',
         'wovn_dev_mode' => false,
-        'compress_api_request' => true
+        'compress_api_requests' => true
       )
     end
 
@@ -182,8 +182,8 @@ module Wovnrb
       @settings['supported_langs'] || []
     end
 
-    def compress_api_request?
-      @settings['compress_api_request']
+    def compress_api_requests?
+      @settings['compress_api_requests']
     end
 
     def widget_url

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '3.2.0'.freeze
+  VERSION = '3.3.0'.freeze
 end

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -27,7 +27,7 @@ module Wovnrb
     end
 
     def test_translate_without_api_compression_sends_json
-      Wovnrb::Store.instance.update_settings('compress_api_request' => false)
+      Wovnrb::Store.instance.update_settings('compress_api_requests' => false)
       sut, store, headers = create_sut
       html_body = 'foo'
 
@@ -53,7 +53,7 @@ module Wovnrb
                          'product' => 'WOVN.rb',
                          'version' => VERSION,
                          'body' => 'foo',
-                         'custom_lang_aliases' =>  { 'ja' => 'Japanese' }.to_json
+                         'custom_lang_aliases' => { 'ja' => 'Japanese' }.to_json
                        }.to_json,
                        :times => 1
     end

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 module Wovnrb
+  REQUEST_UUID = 'ABCD'
+
   class ApiTranslatorTest < WovnMiniTest
     def test_translate
       assert_translation('test.html', 'test_translated.html', true)
@@ -24,6 +26,38 @@ module Wovnrb
       assert_translation('test.html', 'test_translated.html', true, encoding: 'text/json')
     end
 
+    def test_translate_without_api_compression_sends_json
+      Wovnrb::Store.instance.update_settings('compress_api_request' => false)
+      sut, store, headers = create_sut
+      html_body = 'foo'
+
+      stub_request(:post, %r{http://wovn\.global\.ssl\.fastly\.net/v0/translation\?cache_key=.*})
+        .to_return(status: 200, body: { 'body' => 'translated_body' }.to_json)
+
+      sut.translate(html_body)
+
+      assert_requested :post, %r{http://wovn\.global\.ssl\.fastly\.net/v0/translation\?cache_key=.*},
+                       :headers => {
+                         'Accept' => '*/*',
+                         'Accept-Encoding' => 'gzip',
+                         'Content-Type' => 'application/json',
+                         'User-Agent' => 'Ruby',
+                         'X-Request-Id' => REQUEST_UUID
+                       },
+                       :body => {
+                         'url' => 'http://wovn.io/test',
+                         'token' => '123456',
+                         'lang_code' => 'fr',
+                         'url_pattern' => 'subdomain',
+                         'lang_param_name' => 'lang',
+                         'product' => 'WOVN.rb',
+                         'version' => VERSION,
+                         'body' => 'foo',
+                         'custom_lang_aliases' =>  { 'ja' => 'Japanese' }.to_json
+                       }.to_json,
+                       :times => 1
+    end
+
     private
 
     def assert_translation(original_html_fixture, translated_html_fixture, success_expected, response = { encoding: 'gzip', status_code: 200 })
@@ -39,6 +73,15 @@ module Wovnrb
     end
 
     def translate(original_html, translated_html, response)
+      api_translator, store, headers = setup
+      translation_request_stub = stub_translation_api_request(store, headers, original_html, translated_html, response)
+
+      actual_translated_html = api_translator.translate(original_html)
+      assert_requested(translation_request_stub, times: 1) if translation_request_stub
+      actual_translated_html
+    end
+
+    def create_sut
       settings = {
         'project_token' => '123456',
         'custom_lang_aliases' => { 'ja' => 'Japanese' },
@@ -53,12 +96,9 @@ module Wovnrb
         Wovnrb.get_env('url' => 'http://fr.wovn.io/test'),
         Wovnrb.get_settings(settings)
       )
-      api_translator = ApiTranslator.new(store, headers, 'ABCD')
-      translation_request_stub = stub_translation_api_request(store, headers, original_html, translated_html, response)
+      api_translator = ApiTranslator.new(store, headers, REQUEST_UUID)
 
-      actual_translated_html = api_translator.translate(original_html)
-      assert_requested(translation_request_stub, times: 1) if translation_request_stub
-      actual_translated_html
+      [api_translator, store, headers]
     end
 
     def stub_translation_api_request(store, headers, original_html, translated_html, response)

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -73,7 +73,7 @@ module Wovnrb
     end
 
     def translate(original_html, translated_html, response)
-      api_translator, store, headers = setup
+      api_translator, store, headers = create_sut
       translation_request_stub = stub_translation_api_request(store, headers, original_html, translated_html, response)
 
       actual_translated_html = api_translator.translate(original_html)

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module Wovnrb
-  REQUEST_UUID = 'ABCD'
+  REQUEST_UUID = 'ABCD'.freeze
 
   class ApiTranslatorTest < WovnMiniTest
     def test_translate
@@ -28,7 +28,7 @@ module Wovnrb
 
     def test_translate_without_api_compression_sends_json
       Wovnrb::Store.instance.update_settings('compress_api_requests' => false)
-      sut, store, headers = create_sut
+      sut, _store, _headers = create_sut
       html_body = 'foo'
 
       stub_request(:post, %r{http://wovn\.global\.ssl\.fastly\.net/v0/translation\?cache_key=.*})
@@ -37,14 +37,14 @@ module Wovnrb
       sut.translate(html_body)
 
       assert_requested :post, %r{http://wovn\.global\.ssl\.fastly\.net/v0/translation\?cache_key=.*},
-                       :headers => {
+                       headers: {
                          'Accept' => '*/*',
                          'Accept-Encoding' => 'gzip',
                          'Content-Type' => 'application/json',
                          'User-Agent' => 'Ruby',
                          'X-Request-Id' => REQUEST_UUID
                        },
-                       :body => {
+                       body: {
                          'url' => 'http://wovn.io/test',
                          'token' => '123456',
                          'lang_code' => 'fr',
@@ -55,7 +55,7 @@ module Wovnrb
                          'body' => 'foo',
                          'custom_lang_aliases' => { 'ja' => 'Japanese' }.to_json
                        }.to_json,
-                       :times => 1
+                       times: 1
     end
 
     private


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
https://wovnio.atlassian.net/browse/ST-1100
### Comments
We currently gzip the request to html swapper. There is now a compress_api_request setting that can be set to false to disable this.

This is only to make it easier to use MockServer to assert the incoming request as JSON in integration tests.