### PR TITLE
add default fallback logic to treat html-swapper response as plain text

### DIFF
--- a/lib/wovnrb/api_translator.rb
+++ b/lib/wovnrb/api_translator.rb
@@ -24,18 +24,16 @@ module Wovnrb
 
       case response
       when Net::HTTPSuccess
-        if response.header['Content-Encoding'] == 'gzip'
-          response_body = Zlib::GzipReader.new(StringIO.new(response.body)).read
+        begin
+          return JSON.parse(response.body)['body'] || body if @store.dev_mode?
 
+          response_body = Zlib::GzipReader.new(StringIO.new(response.body)).read
           JSON.parse(response_body)['body'] || body
-        elsif @store.dev_mode?
+        rescue Zlib::GzipFile::Error
           JSON.parse(response.body)['body'] || body
-        else
-          WovnLogger.error("Received invalid content (\"#{response.header['Content-Encoding']}\") from WOVNio translation API.")
-          body
         end
       else
-        WovnLogger.error("Received \"#{response.message}\" from WOVNio translation API.")
+        WovnLogger.error("HTML-swapper call failed. Received \"#{response.message}\" from WOVNio translation API.")
         body
       end
     end

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '3.3.1'.freeze
+  VERSION = '3.4.0'.freeze
 end

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -17,8 +17,8 @@ module Wovnrb
       assert_translation('test.html', 'test_translated.html', false, status_code: 500)
     end
 
-    def test_translate_falls_back_to_original_body_if_api_response_is_not_compressed
-      assert_translation('test.html', 'test_translated.html', false, encoding: 'unknown')
+    def test_translate_continues_if_api_response_is_not_compressed
+      assert_translation('test.html', 'test_translated.html', true, encoding: 'unknown')
     end
 
     def test_translate_accepts_uncompressed_response_from_api_in_dev_mode

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -78,7 +78,7 @@ module Wovnrb
 
     def translate(original_html, translated_html, response, compress_data: true)
       api_translator, store, headers = create_sut
-      translation_request_stub = stub_translation_api_request(store, headers, original_html, translated_html, response, compress_data: compress_data)
+      translation_request_stub = stub_translation_api_request(store, original_html, translated_html, response, compress_data: compress_data)
 
       actual_translated_html = api_translator.translate(original_html)
       assert_requested(translation_request_stub, times: 1) if translation_request_stub
@@ -105,7 +105,7 @@ module Wovnrb
       [api_translator, store, headers]
     end
 
-    def stub_translation_api_request(store, headers, original_html, translated_html, response, compress_data: true)
+    def stub_translation_api_request(store, original_html, translated_html, response, compress_data: true)
       if response
         cache_key = generate_cache_key(store, original_html)
         api_host = if store.dev_mode?

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -77,7 +77,7 @@ module Wovnrb
     end
 
     def translate(original_html, translated_html, response, compress_data: true)
-      api_translator, store, headers = create_sut
+      api_translator, store, _headers = create_sut
       translation_request_stub = stub_translation_api_request(store, original_html, translated_html, response, compress_data: compress_data)
 
       actual_translated_html = api_translator.translate(original_html)

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -10,24 +10,24 @@ module Wovnrb
 
     def test_translate_falls_back_to_original_body_if_exception
       Net::HTTP.any_instance.expects(:request).raises
-      assert_translation('test.html', 'test_translated.html', false, nil)
+      assert_translation('test.html', 'test_translated.html', false, response: nil)
     end
 
     def test_translate_falls_back_to_original_body_if_api_error
-      assert_translation('test.html', 'test_translated.html', false, status_code: 500)
+      assert_translation('test.html', 'test_translated.html', false, response: { encoding: 'text/json', status_code: 500 })
     end
 
     def test_translate_continues_if_api_response_is_not_compressed
-      assert_translation('test.html', 'test_translated.html', true, encoding: 'unknown', compress_data: false)
+      assert_translation('test.html', 'test_translated.html', true, response: { encoding: 'unknown', status: 200 }, compress_data: false)
     end
 
     def test_translate_continues_if_api_response_is_compressed
-      assert_translation('test.html', 'test_translated.html', true, encoding: 'unknown')
+      assert_translation('test.html', 'test_translated.html', true, response: { encoding: 'unknown', status: 200 })
     end
 
     def test_translate_accepts_uncompressed_response_from_api_in_dev_mode
       Wovnrb::Store.instance.update_settings('wovn_dev_mode' => true)
-      assert_translation('test.html', 'test_translated.html', true, encoding: 'text/json', compress_data: false)
+      assert_translation('test.html', 'test_translated.html', true, response: { encoding: 'text/json', status: 200 }, compress_data: false)
     end
 
     def test_translate_without_api_compression_sends_json
@@ -64,10 +64,10 @@ module Wovnrb
 
     private
 
-    def assert_translation(original_html_fixture, translated_html_fixture, success_expected, response = { encoding: 'gzip', status_code: 200 })
+    def assert_translation(original_html_fixture, translated_html_fixture, success_expected, response: { encoding: 'gzip', status_code: 200 }, compress_data: true)
       original_html = File.read("test/fixtures/html/#{original_html_fixture}")
       translated_html = File.read("test/fixtures/html/#{translated_html_fixture}")
-      actual_translated_html = translate(original_html, translated_html, response)
+      actual_translated_html = translate(original_html, translated_html, response, compress_data: compress_data)
 
       if success_expected
         assert_equal(actual_translated_html, translated_html)


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
https://wovnio.atlassian.net/browse/ST-914

### Comments
This PR wraps the decompress of response text in a try catch block.
We assume the response is plain text if we cannot use gzip to uncompress it properly.