### PR TITLE
remove -p option for minitest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ require 'pry'
 Rake::TestTask.new do |t|
   t.libs << 'test'
   t.test_files = FileList['test/**/*.rb']
-  t.options = '-p'
 end
 
 task :package do


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Hate to do this but with this option enabled, if there are invalid UTF-8 byte sequences in the diff the test will crash (can happen for tests that deals with gzipped request body stubs). It is confusing if you are not familiar with this behavior. 

### Comments
