### PR TITLE
Fix regexp

### DIFF
--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -151,7 +151,7 @@ module Wovnrb
       when 'query'
         @settings['url_pattern_reg'] = "((\\?.*&)|\\?)#{@settings['lang_param_name']}=(?<lang>[^&]+)(&|$)"
       when 'subdomain'
-        @settings['url_pattern_reg'] = "^(?<lang>[^.]+)."
+        @settings['url_pattern_reg'] = '^(?<lang>[^.]+)\.'
       end
 
       @settings['test_mode'] = !(@settings['test_mode'] != true || @settings['test_mode'] != 'on')

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '3.7.0'.freeze
+  VERSION = '3.7.1'.freeze
 end

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -69,7 +69,7 @@ module Wovnrb
         'custom_lang_aliases' => { 'ja' => 'Japanese' },
         'default_lang' => 'en',
         'url_pattern' => 'subdomain',
-        'url_pattern_reg' => '^(?<lang>[^.]+).',
+        'url_pattern_reg' => '^(?<lang>[^.]+)\.',
         'lang_param_name' => 'lang'
       }
       store = Wovnrb::Store.instance
@@ -89,7 +89,7 @@ module Wovnrb
         'custom_lang_aliases' => { 'ja' => 'Japanese' },
         'default_lang' => 'en',
         'url_pattern' => 'subdomain',
-        'url_pattern_reg' => '^(?<lang>[^.]+).',
+        'url_pattern_reg' => '^(?<lang>[^.]+)\.',
         'lang_param_name' => 'lang'
       }
       store = Wovnrb::Store.instance
@@ -136,7 +136,7 @@ module Wovnrb
         'custom_lang_aliases' => { 'ja' => 'Japanese' },
         'default_lang' => 'en',
         'url_pattern' => 'subdomain',
-        'url_pattern_reg' => '^(?<lang>[^.]+).',
+        'url_pattern_reg' => '^(?<lang>[^.]+)\.',
         'lang_param_name' => 'lang'
       }
       store = Wovnrb::Store.instance

--- a/test/lib/headers_test.rb
+++ b/test/lib/headers_test.rb
@@ -168,7 +168,7 @@ module Wovnrb
       },
       {
         'env' => { 'REQUEST_URI' => 'http://ja.page.com/test/' },
-        'setting' => { 'url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).' },
+        'setting' => { 'url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+)\.' },
         'name' => 'test_pathname_with_trailing_slash_if_present_with_subdomain_lang_when_trailing_slash_is_present',
         'expected' => {
           'pathname_with_trailing_slash_if_present' => '/test/'
@@ -234,7 +234,7 @@ module Wovnrb
     REDIRECT_LOCATION_TESTS = [
       {
         'env' => { 'url' => 'http://wovn.io/contact', 'HTTP_X_FORWARDED_HOST' => 'wovn.io' },
-        'setting' => { 'url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).' },
+        'setting' => { 'url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+)\.' },
         'name' => 'test_redirect_location_without_custom_lang_code',
         'expected' => {
           'redirect_location' => {
@@ -244,7 +244,7 @@ module Wovnrb
       },
       {
         'env' => { 'url' => 'http://wovn.io/contact', 'HTTP_X_FORWARDED_HOST' => 'wovn.io' },
-        'setting' => { 'url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+).', 'custom_lang_aliases' => { 'ja' => 'staging-ja' } },
+        'setting' => { 'url_pattern' => 'subdomain', 'url_pattern_reg' => '^(?<lang>[^.]+)\.', 'custom_lang_aliases' => { 'ja' => 'staging-ja' } },
         'name' => 'test_redirect_location_with_custom_lang_code',
         'expected' => {
           'redirect_location' => {
@@ -297,7 +297,7 @@ module Wovnrb
     def test_request_out_with_wovn_target_lang_header_using_subdomain
       settings = Wovnrb.get_settings({
                                        'url_pattern' => 'subdomain',
-                                       'url_pattern_reg' => '^(?<lang>[^.]+).'
+                                       'url_pattern_reg' => '^(?<lang>[^.]+)\.'
                                      })
       store = Wovnrb.get_store(settings)
       env = Wovnrb.get_env({
@@ -345,7 +345,7 @@ module Wovnrb
     def test_request_out_with_use_proxy_false
       settings = Wovnrb.get_settings({
                                        'url_pattern' => 'subdomain',
-                                       'url_pattern_reg' => '^(?<lang>[^.]+).'
+                                       'url_pattern_reg' => '^(?<lang>[^.]+)\.'
                                      })
       store = Wovnrb.get_store(settings)
       env = Wovnrb.get_env({
@@ -362,7 +362,7 @@ module Wovnrb
     def test_request_out_with_use_proxy_true
       settings = Wovnrb.get_settings({
                                        'url_pattern' => 'subdomain',
-                                       'url_pattern_reg' => '^(?<lang>[^.]+).',
+                                       'url_pattern_reg' => '^(?<lang>[^.]+)\.',
                                        'use_proxy' => true
                                      })
       store = Wovnrb.get_store(settings)
@@ -380,7 +380,7 @@ module Wovnrb
     def test_request_out_http_referer_subdomain
       settings = Wovnrb.get_settings({
                                        'url_pattern' => 'subdomain',
-                                       'url_pattern_reg' => '^(?<lang>[^.]+).'
+                                       'url_pattern_reg' => '^(?<lang>[^.]+)\.'
                                      })
       store = Wovnrb.get_store(settings)
       env = Wovnrb.get_env({
@@ -413,7 +413,7 @@ module Wovnrb
       settings = Wovnrb.get_settings({
                                        'custom_lang_aliases' => { 'ja' => 'staging-ja' },
                                        'url_pattern' => 'subdomain',
-                                       'url_pattern_reg' => '^(?<lang>[^.]+).'
+                                       'url_pattern_reg' => '^(?<lang>[^.]+)\.'
                                      })
       store = Wovnrb.get_store(settings)
       env = Wovnrb.get_env({
@@ -475,7 +475,7 @@ module Wovnrb
       settings = Wovnrb.get_settings({
                                        'custom_lang_aliases' => { 'ja' => 'staging-ja' },
                                        'url_pattern' => 'subdomain',
-                                       'url_pattern_reg' => '^(?<lang>[^.]+).'
+                                       'url_pattern_reg' => '^(?<lang>[^.]+)\.'
                                      })
       store = Wovnrb.get_store(settings)
       env = Wovnrb.get_env({
@@ -494,7 +494,7 @@ module Wovnrb
     def test_out_original_lang_with_subdomain_url_pattern
       settings = Wovnrb.get_settings({
                                        'url_pattern' => 'subdomain',
-                                       'url_pattern_reg' => '^(?<lang>[^.]+).'
+                                       'url_pattern_reg' => '^(?<lang>[^.]+)\.'
                                      })
       store = Wovnrb.get_store(settings)
       env = Wovnrb.get_env({
@@ -551,7 +551,7 @@ module Wovnrb
     def test_out_with_wovn_target_lang_header_using_subdomain
       settings = Wovnrb.get_settings({
                                        'url_pattern' => 'subdomain',
-                                       'url_pattern_reg' => '^(?<lang>[^.]+).'
+                                       'url_pattern_reg' => '^(?<lang>[^.]+)\.'
                                      })
       store = Wovnrb.get_store(settings)
       env = Wovnrb.get_env({
@@ -759,7 +759,7 @@ module Wovnrb
     def test_path_lang_sudomain_with_use_proxy_false
       settings = Wovnrb.get_settings({
                                        'url_pattern' => 'subdomain',
-                                       'url_pattern_reg' => '^(?<lang>[^.]+).'
+                                       'url_pattern_reg' => '^(?<lang>[^.]+)\.'
                                      })
       store = Wovnrb.get_store(settings)
       env = Wovnrb.get_env({
@@ -774,7 +774,7 @@ module Wovnrb
     def test_path_lang_sudomain_with_use_proxy_true
       settings = Wovnrb.get_settings({
                                        'url_pattern' => 'subdomain',
-                                       'url_pattern_reg' => '^(?<lang>[^.]+).',
+                                       'url_pattern_reg' => '^(?<lang>[^.]+)\.',
                                        'use_proxy' => true
                                      })
       store = Wovnrb.get_store(settings)

--- a/test/lib/store_test.rb
+++ b/test/lib/store_test.rb
@@ -44,7 +44,7 @@ module Wovnrb
     def test_settings_url_pattern_subdomain
       s = Wovnrb::Store.instance
       s.update_settings('url_pattern' => 'subdomain')
-      assert_equal('^(?<lang>[^.]+).', s.settings['url_pattern_reg'])
+      assert_equal('^(?<lang>[^.]+)\.', s.settings['url_pattern_reg'])
       assert_equal('subdomain', s.settings['url_pattern'])
     end
 

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -283,7 +283,7 @@ HTML
       'custom_lang_aliases' => {},
       'default_lang' => original_lang,
       'url_pattern' => 'subdomain',
-      'url_pattern_reg' => '^(?<lang>[^.]+).'
+      'url_pattern_reg' => '^(?<lang>[^.]+)\.'
     }
 
     store = Wovnrb::Store.instance


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
In https://github.com/WOVNio/wovnrb/pull/215 , Rubocop changed from `"^(?<lang>[^.]+)\."` to `'^(?<lang>[^.]+).'`.
String in Ruby has the following behavior. Notice that `"` and `'` has different behavior.
- `"\\."` == `'\.'`
- `"\."` == `'.'`

To find subdomain's lang code, `.` character should be after language code.
So, regexp should be `'^(?<lang>[^.]+)\.'` .

I changed all hard coded regexp.