### PR TITLE
fix: Removing lang codes with path pattern only removes from the first path segment

### DIFF
--- a/lib/wovnrb/url_language_switcher.rb
+++ b/lib/wovnrb/url_language_switcher.rb
@@ -44,7 +44,15 @@ module Wovnrb
         rp = Regexp.new("(^|(//))#{lang_code}\\.", 'i')
         uri.sub(rp, '\1')
       when 'path'
-        uri.sub(%r{/#{lang_code}(/|$)}, '/')
+        protocol_match = uri.match(%r{^([^/]+//)})
+        protocol = ''
+        if protocol_match
+          protocol = protocol_match[1]
+          uri = uri.sub(protocol, '')
+        end
+        lang_code_pattern = %r{(^/|[^/]+/)#{lang_code}(/|$)}
+        uri = uri.sub(lang_code_pattern, '\1')
+        protocol + uri
       else
         raise RuntimeError("Invalid URL pattern: #{@store.settings['url_pattern']}")
       end

--- a/lib/wovnrb/url_language_switcher.rb
+++ b/lib/wovnrb/url_language_switcher.rb
@@ -44,15 +44,11 @@ module Wovnrb
         rp = Regexp.new("(^|(//))#{lang_code}\\.", 'i')
         uri.sub(rp, '\1')
       when 'path'
-        protocol_match = uri.match(%r{^([^/]+//)})
-        protocol = ''
-        if protocol_match
-          protocol = protocol_match[1]
-          uri = uri.sub(protocol, '')
-        end
-        lang_code_pattern = %r{(^/|[^/]+/)#{lang_code}(/|$)}
-        uri = uri.sub(lang_code_pattern, '\1')
-        protocol + uri
+        # ^(.*://|//)?  1: schema (optional) like https://
+        # ([^/]*/)?     2: host (optional) like wovn.io, with trailing '/' (mandatory)
+        # (/|$)         3: path or end-of-string
+        lang_code_pattern = %r{^(.*://|//)?([^/]*/)?#{lang_code}(/|$)}
+        uri.sub(lang_code_pattern, '\1\2')
       else
         raise RuntimeError("Invalid URL pattern: #{@store.settings['url_pattern']}")
       end

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '3.7.1'.freeze
+  VERSION = '3.7.2'.freeze
 end

--- a/test/lib/url_language_switcher_test.rb
+++ b/test/lib/url_language_switcher_test.rb
@@ -876,17 +876,20 @@ module Wovnrb
     def test_remove_lang_path
       settings = Wovnrb.get_settings
       store = Wovnrb.get_store(settings)
-      url_lang_switcher = UrlLanguageSwitcher.new(store)
+      sut = UrlLanguageSwitcher.new(store)
 
       keys = Wovnrb::Lang::LANG.keys
       assert_equal(77, keys.size)
 
       keys.each do |key|
-        uri_without_scheme = url_lang_switcher.remove_lang_from_uri_component("wovn.io/#{key}", key)
-        assert_equal('wovn.io/', uri_without_scheme)
-
-        uri_with_scheme = url_lang_switcher.remove_lang_from_uri_component("https://wovn.io/#{key}/", key)
-        assert_equal('https://wovn.io/', uri_with_scheme)
+        assert_equal('/', sut.remove_lang_from_uri_component("/#{key}", key))
+        assert_equal("/dir/#{key}/page.html", sut.remove_lang_from_uri_component("/#{key}/dir/#{key}/page.html", key))
+        assert_equal('?query', sut.remove_lang_from_uri_component("?query", key))
+        assert_equal('wovn.io/', sut.remove_lang_from_uri_component("wovn.io/#{key}", key))
+        assert_equal("wovn.io/dir/#{key}/page.html", sut.remove_lang_from_uri_component("wovn.io/#{key}/dir/#{key}/page.html", key))
+        assert_equal("wovn.io:5000/dir/#{key}/page.html", sut.remove_lang_from_uri_component("wovn.io:5000/#{key}/dir/#{key}/page.html", key))
+        assert_equal('https://wovn.io/', sut.remove_lang_from_uri_component("https://wovn.io/#{key}/", key))
+        assert_equal("https://wovn.io/dir/#{key}/page.html", sut.remove_lang_from_uri_component("https://wovn.io/#{key}/dir/#{key}/page.html", key))
       end
     end
 

--- a/test/lib/url_language_switcher_test.rb
+++ b/test/lib/url_language_switcher_test.rb
@@ -884,7 +884,7 @@ module Wovnrb
       keys.each do |key|
         assert_equal('/', sut.remove_lang_from_uri_component("/#{key}", key))
         assert_equal("/dir/#{key}/page.html", sut.remove_lang_from_uri_component("/#{key}/dir/#{key}/page.html", key))
-        assert_equal('?query', sut.remove_lang_from_uri_component("?query", key))
+        assert_equal('?query', sut.remove_lang_from_uri_component('?query', key))
         assert_equal('wovn.io/', sut.remove_lang_from_uri_component("wovn.io/#{key}", key))
         assert_equal("wovn.io/dir/#{key}/page.html", sut.remove_lang_from_uri_component("wovn.io/#{key}/dir/#{key}/page.html", key))
         assert_equal("wovn.io:5000/dir/#{key}/page.html", sut.remove_lang_from_uri_component("wovn.io:5000/#{key}/dir/#{key}/page.html", key))


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Bug: URLs like `http://site.com/dir/en/page.html` would be incorrectly modified to `http://site.com/dir/page.html`. We should only handle the "wovn" lang code like `http://site.com/en/dir/page.html`. The user is allowed to use lang codes in other directories.
### Comments
