### PR TITLE
fix: change es-RA to es-AR

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,6 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 2.5
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,3 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 2.5
-
-Gemspec/DevelopmentDependencies:
-  EnforcedStyle: gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,30 @@
 source 'https://rubygems.org'
 gemspec
+
+# All gems below are development dependencies
+gem 'bundler', '>= 1.7'
+gem 'guard'
+gem 'guard-rspec'
+gem 'listen', '~> 3.0.6'
+gem 'minitest'
+gem 'mocha'
+gem 'pry'
+gem 'pry-nav'
+gem 'pry-remote'
+gem 'rake', '~> 10.0'
+gem 'rb-readline'
+gem 'shoulda-context'
+gem 'terminal-notifier'
+gem 'test-unit'
+gem 'test-unit-notify'
+
+gem 'rake-compiler'
+gem 'rubocop'
+gem 'rubocop-performance'
+gem 'timecop'
+
+# NOTE; it need to use webmock 2.3.2 for avoiding error when we use ruby 2.4.x.
+# https://github.com/bblimke/webmock/issues/683
+gem 'public_suffix', '~> 1.4.6'
+gem 'simplecov'
+gem 'webmock', '>= 2.3.2'

--- a/lib/wovnrb/lang.rb
+++ b/lib/wovnrb/lang.rb
@@ -56,7 +56,7 @@ module Wovnrb
       'pt-PT' => { name: 'Português (Portugal)',     code: 'pt-PT',      en: 'Portuguese (Portugal)' },
       'ru' => { name: 'Русский',                  code: 'ru',         en: 'Russian' },
       'es' => { name: 'Español',                  code: 'es',         en: 'Spanish' },
-      'es-RA' => { name: 'Español (Argentina)',      code: 'es-RA',      en: 'Spanish (Argentina)' },
+      'es-AR' => { name: 'Español (Argentina)',      code: 'es-AR',      en: 'Spanish (Argentina)' },
       'es-CL' => { name: 'Español (Chile)',          code: 'es-CL',      en: 'Spanish (Chile)' },
       'es-CO' => { name: 'Español (Colombia)',       code: 'es-CO',      en: 'Spanish (Colombia)' },
       'es-CR' => { name: 'Español (Costa Rica)',     code: 'es-CR',      en: 'Spanish (Costa Rica)' },

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '3.7.2'.freeze
+  VERSION = '3.8.0'.freeze
 end

--- a/wovnrb.gemspec
+++ b/wovnrb.gemspec
@@ -25,31 +25,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'lz4-ruby'
   spec.add_dependency 'nokogiri', '>= 1.12', '<2'
   spec.add_dependency 'rack'
-
-  spec.add_development_dependency 'bundler', '>= 1.7'
-  spec.add_development_dependency 'guard'
-  spec.add_development_dependency 'guard-rspec'
-  spec.add_development_dependency 'listen', '~> 3.0.6'
-  spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'mocha'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'pry-nav'
-  spec.add_development_dependency 'pry-remote'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rb-readline'
-  spec.add_development_dependency 'shoulda-context'
-  spec.add_development_dependency 'terminal-notifier'
-  spec.add_development_dependency 'test-unit'
-  spec.add_development_dependency 'test-unit-notify'
-
-  spec.add_development_dependency 'rake-compiler'
-  spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'rubocop-performance'
-  spec.add_development_dependency 'timecop'
-
-  # NOTE; it need to use webmock 2.3.2 for avoiding error when we use ruby 2.4.x.
-  # https://github.com/bblimke/webmock/issues/683
-  spec.add_development_dependency 'public_suffix', '~> 1.4.6'
-  spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'webmock', '>= 2.3.2'
 end


### PR DESCRIPTION
This changes es-RA to es-AR

See https://wovnio.slack.com/archives/C03AA9V3E/p1674539995055339 for more information

Also, without changing master, rubocop now fails locally and on CI?!  I adjusted how we import dev dependencies to make rubocop happy. Feedback welcome.