### PR TITLE
fix: [ST-2294] Hreflangs are inserted for pages that don't need translation

### DIFF
--- a/lib/wovnrb/services/html_converter.rb
+++ b/lib/wovnrb/services/html_converter.rb
@@ -134,7 +134,7 @@ module Wovnrb
 
     def replace_hreflangs
       strip_hreflang_tags
-      insert_hreflang_tags
+      insert_hreflang_tags if @store.settings['insert_hreflangs']
     end
 
     def strip_hreflang_tags

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '3.10.0'.freeze
+  VERSION = '3.10.1'.freeze
 end

--- a/test/lib/services/html_converter_test.rb
+++ b/test/lib/services/html_converter_test.rb
@@ -455,10 +455,10 @@ module Wovnrb
     test 'build API compatible html - with insert_hreflangs: false - hreflangs are not added' do
       settings = default_store_settings
       settings['insert_hreflangs'] = false
-      converter = prepare_html_converter('<html><body><a class="test">hello</a></body></html>', settings)
+      converter = prepare_html_converter('<html><body><a>hello</a></body></html>', settings)
       converted_html, = converter.build_api_compatible_html
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body><a class=\"test\">hello</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body><a>hello</a></body></html>"
       assert_equal(expected_html, converted_html)
     end
 

--- a/test/lib/services/html_converter_test.rb
+++ b/test/lib/services/html_converter_test.rb
@@ -452,6 +452,26 @@ module Wovnrb
       assert(translated_html.include?(expected_html))
     end
 
+    test 'build API compatible html - with insert_hreflangs: false - hreflangs are not added' do
+      settings = default_store_settings
+      settings['insert_hreflangs'] = false
+      converter = prepare_html_converter('<html><body><a class="test">hello</a></body></html>', settings)
+      converted_html, = converter.build_api_compatible_html
+
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body><a class=\"test\">hello</a></body></html>"
+      assert_equal(expected_html, converted_html)
+    end
+
+    test 'Transform HTML - with insert_hreflangs: false - hreflangs are not added' do
+      settings = default_store_settings
+      settings['insert_hreflangs'] = false
+      converter = prepare_html_converter('<html><body><a>hello</a></body></html>', settings)
+      translated_html = converter.build
+
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body><a>hello</a></body></html>"
+      assert_equal(expected_html, translated_html)
+    end
+
     private
 
     def prepare_html_converter(input_html, store_options = {})
@@ -472,15 +492,6 @@ module Wovnrb
       )
 
       [store, headers]
-    end
-
-    test 'build API compatible html - with insert_hreflangs: false' do
-      settings = { insert_hreflangs: false }
-      converter = prepare_html_converter('<html><body><a class="test">hello</a></body></html>', settings)
-      converted_html, = converter.build_api_compatible_html
-
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body><a class=\"test\">hello</a></body></html>"
-      assert_equal(expected_html, converted_html)
     end
 
     def default_store_settings


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)

Follow-up to #233.

Fixes issue where pages that don't need translation (e.g. pages displayed in default language) have hreflangs inserted.

### Comments
