### PR TITLE
fix: [ST-2294] Hreflangs are removed when having `insert_hreflangs: false`

### DIFF
--- a/lib/wovnrb/services/html_converter.rb
+++ b/lib/wovnrb/services/html_converter.rb
@@ -42,7 +42,7 @@ module Wovnrb
 
     def transform_html
       replace_snippet
-      replace_hreflangs
+      replace_hreflangs if @store.settings['insert_hreflangs']
       inject_lang_html_tag
       translate_canonical_tag if @store.settings['translate_canonical_tag']
     end
@@ -54,7 +54,7 @@ module Wovnrb
 
     def replace_dom(marker)
       strip_snippet
-      strip_hreflangs if add_hreflang
+      strip_hreflangs if add_hreflang && @store.settings['insert_hreflangs']
 
       @dom.traverse { |node| transform_node(node, marker) }
 
@@ -134,7 +134,7 @@ module Wovnrb
 
     def replace_hreflangs
       strip_hreflang_tags
-      insert_hreflang_tags if @store.settings['insert_hreflangs']
+      insert_hreflang_tags
     end
 
     def strip_hreflang_tags

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '3.10.1'.freeze
+  VERSION = '3.10.2'.freeze
 end

--- a/test/lib/services/html_converter_test.rb
+++ b/test/lib/services/html_converter_test.rb
@@ -465,7 +465,7 @@ module Wovnrb
     test 'build API compatible html - with insert_hreflangs: false - original hreflangs are not removed' do
       settings = default_store_settings
       settings['insert_hreflangs'] = false
-      converter = prepare_html_converter("<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>", settings)
+      converter = prepare_html_converter('<html><head><link rel="alternate" hreflang="en" href="http://my-site.com/"><link rel="alternate" hreflang="vi" href="http://my-site.com/?wovn=vi"></head><body><a>hello</a></body></html>', settings)
       converted_html, = converter.build_api_compatible_html
 
       expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"
@@ -476,6 +476,16 @@ module Wovnrb
       settings = default_store_settings
       settings['insert_hreflangs'] = false
       converter = prepare_html_converter("<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>", settings)
+      translated_html = converter.build
+
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"
+      assert_equal(expected_html, translated_html)
+    end
+
+    test 'Transform HTML - with insert_hreflangs: false - original hreflangs are not removed' do
+      settings = default_store_settings
+      settings['insert_hreflangs'] = false
+      converter = prepare_html_converter('<html><head><link rel="alternate" hreflang="en" href="http://my-site.com/"><link rel="alternate" hreflang="vi" href="http://my-site.com/?wovn=vi"></head><body><a>hello</a></body></html>', settings)
       translated_html = converter.build
 
       expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"

--- a/test/lib/services/html_converter_test.rb
+++ b/test/lib/services/html_converter_test.rb
@@ -475,10 +475,10 @@ module Wovnrb
     test 'Transform HTML - with insert_hreflangs: false - hreflangs are not added' do
       settings = default_store_settings
       settings['insert_hreflangs'] = false
-      converter = prepare_html_converter("<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>", settings)
+      converter = prepare_html_converter('<html><body><a>hello</a></body></html>', settings)
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body><a>hello</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 

--- a/test/lib/services/html_converter_test.rb
+++ b/test/lib/services/html_converter_test.rb
@@ -462,13 +462,23 @@ module Wovnrb
       assert_equal(expected_html, converted_html)
     end
 
+    test 'build API compatible html - with insert_hreflangs: false - original hreflangs are not removed' do
+      settings = default_store_settings
+      settings['insert_hreflangs'] = false
+      converter = prepare_html_converter("<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>", settings)
+      converted_html, = converter.build_api_compatible_html
+
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"
+      assert_equal(expected_html, converted_html)
+    end
+
     test 'Transform HTML - with insert_hreflangs: false - hreflangs are not added' do
       settings = default_store_settings
       settings['insert_hreflangs'] = false
-      converter = prepare_html_converter('<html><body><a>hello</a></body></html>', settings)
+      converter = prepare_html_converter("<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>", settings)
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body><a>hello</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)

See also #233, #234.

Fixes issue where original hreflangs are removed when having `insert_hreflangs: false` (WOVN hreflangs are not inserted).

### Comments
