### PR TITLE
feat: [ST-2310] Support `use_cookie_lang` setting

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -37,7 +37,7 @@ module Wovnrb
 
       cookie_lang = Rack::Request.new(env).cookies['wovn_selected_lang']
       request_lang = headers.lang_code
-      if @store.settings['use_cookie_lang'] && request_lang != cookie_lang && request_lang == @store.default_lang
+      if @store.settings['use_cookie_lang'] && cookie_lang.present? && request_lang != cookie_lang && request_lang == @store.default_lang
         redirect_headers = headers.redirect(cookie_lang)
         return [302, redirect_headers, ['']]
       end

--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -35,6 +35,13 @@ module Wovnrb
       default_lang = @store.settings['default_lang']
       return @app.call(env) if @store.settings['test_mode'] && @store.settings['test_url'] != headers.url
 
+      cookie_lang = Rack::Request.new(env).cookies['wovn_selected_lang']
+      request_lang = headers.lang_code
+      if @store.settings['use_cookie_lang'] && request_lang != cookie_lang && request_lang == @store.default_lang
+        redirect_headers = headers.redirect(cookie_lang)
+        return [302, redirect_headers, ['']]
+      end
+
       # redirect if the path is set to the default language (for SEO purposes)
       if explicit_default_lang?(headers)
         redirect_headers = headers.redirect(default_lang)

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -41,7 +41,8 @@ module Wovnrb
         'compress_api_requests' => true,
         'translate_canonical_tag' => true,
         'custom_domain_langs' => {},
-        'insert_hreflangs' => true
+        'insert_hreflangs' => true,
+        'use_cookie_lang' => false,
       )
     end
 

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -42,7 +42,7 @@ module Wovnrb
         'translate_canonical_tag' => true,
         'custom_domain_langs' => {},
         'insert_hreflangs' => true,
-        'use_cookie_lang' => false,
+        'use_cookie_lang' => false
       )
     end
 

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '3.10.3'.freeze
+  VERSION = '3.11.0'.freeze
 end

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -292,6 +292,28 @@ HTML
     assert_nil(res_headers['location'])
   end
 
+  def test_call__with_use_cookie_lang_true__cookie_lang_is_empty__should_not_redirect
+    settings = {
+      'project_token' => '123456',
+      'url_pattern' => 'path',
+      'default_lang' => 'ja',
+      'supported_langs' => %w[ja en],
+      'use_cookie_lang' => true
+    }
+    env = Wovnrb.get_env(
+      {
+        'url' => 'http://test.com/foo',
+        'HTTP_COOKIE' => ''
+      }
+    )
+
+    sut = Wovnrb::Interceptor.new(get_app, settings)
+    status, res_headers, _body = sut.call(env)
+
+    assert_equal(200, status)
+    assert_nil(res_headers['location'])
+  end
+
   private
 
   def assert_call_affects_env(settings, env, mock_api:, affected:)

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -337,6 +337,28 @@ HTML
     assert_nil(res_headers['location'])
   end
 
+  def test_call__with_use_cookie_lang_false__should_not_redirect
+    settings = {
+      'project_token' => '123456',
+      'url_pattern' => 'path',
+      'default_lang' => 'ja',
+      'supported_langs' => %w[ja en],
+      'use_cookie_lang' => false
+    }
+    env = Wovnrb.get_env(
+      {
+        'url' => 'http://test.com/foo',
+        'HTTP_COOKIE' => 'wovn_selected_lang=en'
+      }
+    )
+
+    sut = Wovnrb::Interceptor.new(get_app, settings)
+    status, res_headers, _body = sut.call(env)
+
+    assert_equal(200, status)
+    assert_nil(res_headers['location'])
+  end
+
   private
 
   def assert_call_affects_env(settings, env, mock_api:, affected:)

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -256,10 +256,12 @@ HTML
       'supported_langs' => %w[ja en],
       'use_cookie_lang' => true
     }
-    env = Wovnrb.get_env({
-      'url' => 'http://test.com/foo',
-      'HTTP_COOKIE' => 'wovn_selected_lang=en'
-    })
+    env = Wovnrb.get_env(
+      {
+        'url' => 'http://test.com/foo',
+        'HTTP_COOKIE' => 'wovn_selected_lang=en'
+      }
+    )
 
     sut = Wovnrb::Interceptor.new(get_app, settings)
     status, res_headers, _body = sut.call(env)
@@ -276,10 +278,12 @@ HTML
       'supported_langs' => %w[ja en],
       'use_cookie_lang' => true
     }
-    env = Wovnrb.get_env({
-      'url' => 'http://test.com/foo',
-      'HTTP_COOKIE' => 'wovn_selected_lang=ja'
-    })
+    env = Wovnrb.get_env(
+      {
+        'url' => 'http://test.com/foo',
+        'HTTP_COOKIE' => 'wovn_selected_lang=ja'
+      }
+    )
 
     sut = Wovnrb::Interceptor.new(get_app, settings)
     status, res_headers, _body = sut.call(env)

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -239,12 +239,53 @@ HTML
       'rack.request.form_input' => '',
       'rack.request.form_hash' => {},
       'rack.request.form_pairs' => [],
+      'rack.request.cookie_hash' => {},
       'HTTP_HOST' => 'test.com',
       'REQUEST_URI' => '/en/ignored',
       'PATH_INFO' => '/en/ignored'
     }
 
     assert_call_affects_env(settings, env, mock_api: false, affected: false)
+  end
+
+  def test_call__with_use_cookie_lang_true__cookie_lang_is_target_lang__should_redirect
+    settings = {
+      'project_token' => '123456',
+      'url_pattern' => 'path',
+      'default_lang' => 'ja',
+      'supported_langs' => %w[ja en],
+      'use_cookie_lang' => true
+    }
+    env = Wovnrb.get_env({
+      'url' => 'http://test.com/foo',
+      'HTTP_COOKIE' => 'wovn_selected_lang=en'
+    })
+
+    sut = Wovnrb::Interceptor.new(get_app, settings)
+    status, res_headers, _body = sut.call(env)
+
+    assert_equal(302, status)
+    assert_equal('http://test.com/en/foo', res_headers['location'])
+  end
+
+  def test_call__with_use_cookie_lang_true__cookie_lang_is_default_lang__should_not_redirect
+    settings = {
+      'project_token' => '123456',
+      'url_pattern' => 'path',
+      'default_lang' => 'ja',
+      'supported_langs' => %w[ja en],
+      'use_cookie_lang' => true
+    }
+    env = Wovnrb.get_env({
+      'url' => 'http://test.com/foo',
+      'HTTP_COOKIE' => 'wovn_selected_lang=ja'
+    })
+
+    sut = Wovnrb::Interceptor.new(get_app, settings)
+    status, res_headers, _body = sut.call(env)
+
+    assert_equal(200, status)
+    assert_nil(res_headers['location'])
   end
 
   private

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -292,6 +292,29 @@ HTML
     assert_nil(res_headers['location'])
   end
 
+  def test_call__with_use_cookie_lang_true__cookie_lang_is_different_target_lang__should_not_redirect
+    settings = {
+      'project_token' => '123456',
+      'url_pattern' => 'path',
+      'default_lang' => 'ja',
+      'supported_langs' => %w[ja en fr],
+      'use_cookie_lang' => true
+    }
+    env = Wovnrb.get_env(
+      {
+        'url' => 'http://test.com/en/foo',
+        'HTTP_COOKIE' => 'wovn_selected_lang=fr'
+      }
+    )
+
+    mock_translation_api_response('', '')
+    sut = Wovnrb::Interceptor.new(get_app, settings)
+    status, res_headers, _body = sut.call(env)
+
+    assert_equal(200, status)
+    assert_nil(res_headers['location'])
+  end
+
   def test_call__with_use_cookie_lang_true__cookie_lang_is_empty__should_not_redirect
     settings = {
       'project_token' => '123456',


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)

https://wovnio.atlassian.net/browse/ST-2310

Adds support for `use_cookie_lang` setting, which allows the backend to return `302 Found` response if a cookie language is set to a target language and when the visited URL is in the default language.

For example, when the following URL is accessed:
```
http://example.com/foo
```
and cookie language is set to `ja`, then the URL will be redirected to:
```
http://example.com/ja/foo
```

### Comments
