### PR TITLE
fix: ignore_paths are now checked before we do any translation logic

### DIFF
--- a/lib/wovnrb.rb
+++ b/lib/wovnrb.rb
@@ -40,8 +40,16 @@ module Wovnrb
       request_lang = headers.lang_code
       is_get_request = request.get?
 
+      # if path is ignored, do nothing
+      if ignore_path?(headers.unmasked_pathname_without_trailing_slash)
+        status, res_headers, body = @app.call(env)
+
+        return output(headers, status, res_headers, body)
+      end
+
       if @store.settings['use_cookie_lang'] && cookie_lang.present? && request_lang != cookie_lang && request_lang == @store.default_lang && is_get_request
         redirect_headers = headers.redirect(cookie_lang)
+        redirect_headers['Access-Control-Allow-Origin'] = 'nginx.test'
         return [302, redirect_headers, ['']]
       end
 
@@ -51,12 +59,6 @@ module Wovnrb
         return [307, redirect_headers, ['']]
       end
 
-      # if path containing language code is ignored, do nothing
-      if headers.lang_code != default_lang && ignore_path?(headers.unmasked_pathname_without_trailing_slash)
-        status, res_headers, body = @app.call(env)
-
-        return output(headers, status, res_headers, body)
-      end
       # pass to application
       status, res_headers, body = @app.call(headers.request_out)
 

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -165,7 +165,11 @@ module Wovnrb
 
       if @settings['wovn_dev_mode']
         if @settings['api_url'] == self.class.default_settings['api_url']
-          @settings['api_url'] = 'http://dev-wovn.io:3001'
+          @settings['api_url'] = 'https://dev-wovn.io'
+        end
+
+        if @settings['widget_url'] == self.class.default_settings['widget_url']
+          @settings['widget_url'] = 'https://j.dev-wovn.io/1'
         end
 
         if @settings['api_timeout_seconds'] == self.class.default_settings['api_timeout_seconds']

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '3.11.1'.freeze
+  VERSION = '4.0.0'.freeze
 end

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -156,7 +156,7 @@ module Wovnrb
       if response
         cache_key = generate_cache_key(store, original_html)
         api_host = if store.dev_mode?
-                     'dev-wovn.io:3001'
+                     'dev-wovn.io'
                    else
                      'wovn.global.ssl.fastly.net'
                    end

--- a/test/lib/wovnrb_test.rb
+++ b/test/lib/wovnrb_test.rb
@@ -158,72 +158,6 @@ HTML
     assert_call_affects_env(settings, env, mock_api: true, affected: true)
   end
 
-  def test_call_with_path_ignored_with_language_code_should_change_environment
-    settings = {
-      'project_token' => '123456',
-      'url_pattern' => 'path',
-      'default_lang' => 'ja',
-      'supported_langs' => %w[ja en],
-      'ignore_paths' => ['/en/ignored']
-    }
-    env = {
-      'rack.input' => '',
-      'rack.request.query_string' => '',
-      'rack.request.query_hash' => {},
-      'rack.request.form_input' => '',
-      'rack.request.form_hash' => {},
-      'HTTP_HOST' => 'test.com',
-      'REQUEST_URI' => '/ignored',
-      'PATH_INFO' => '/ignored'
-    }
-
-    assert_call_affects_env(settings, env, mock_api: false, affected: true)
-  end
-
-  def test_call_with_path_ignored_without_language_code_should_change_environment
-    settings = {
-      'project_token' => '123456',
-      'url_pattern' => 'path',
-      'default_lang' => 'ja',
-      'supported_langs' => %w[ja en],
-      'ignore_paths' => ['/ignored']
-    }
-    env = {
-      'rack.input' => '',
-      'rack.request.query_string' => '',
-      'rack.request.query_hash' => {},
-      'rack.request.form_input' => '',
-      'rack.request.form_hash' => {},
-      'HTTP_HOST' => 'test.com',
-      'REQUEST_URI' => '/en/ignored',
-      'PATH_INFO' => '/en/ignored'
-    }
-
-    assert_call_affects_env(settings, env, mock_api: false, affected: true)
-  end
-
-  def test_call_with_path_ignored_without_language_code_in_original_language_should_change_environment
-    settings = {
-      'project_token' => '123456',
-      'url_pattern' => 'path',
-      'default_lang' => 'ja',
-      'supported_langs' => %w[ja en],
-      'ignore_paths' => ['/ignored']
-    }
-    env = {
-      'rack.input' => '',
-      'rack.request.query_string' => '',
-      'rack.request.query_hash' => {},
-      'rack.request.form_input' => '',
-      'rack.request.form_hash' => {},
-      'HTTP_HOST' => 'test.com',
-      'REQUEST_URI' => '/ignored',
-      'PATH_INFO' => '/ignored'
-    }
-
-    assert_call_affects_env(settings, env, mock_api: false, affected: true)
-  end
-
   def test_call_with_path_ignored_should_not_change_environment
     settings = {
       'project_token' => '123456',
@@ -246,6 +180,29 @@ HTML
     }
 
     assert_call_affects_env(settings, env, mock_api: false, affected: false)
+  end
+
+  def test_call__with_use_cookie_lang_true__is_ignored_path__does_nothing
+    settings = {
+      'project_token' => '123456',
+      'url_pattern' => 'path',
+      'default_lang' => 'ja',
+      'supported_langs' => %w[ja en],
+      'ignore_paths' => %w[/ignored/**],
+      'use_cookie_lang' => true
+    }
+    env = Wovnrb.get_env(
+      {
+        'url' => 'http://test.com/ignored/foo',
+        'HTTP_COOKIE' => 'wovn_selected_lang=en'
+      }
+    )
+
+    sut = Wovnrb::Interceptor.new(get_app, settings)
+    status, res_headers, _body = sut.call(env)
+
+    assert_equal(200, status)
+    assert_nil(res_headers['Location'])
   end
 
   def test_call__with_use_cookie_lang_true__cookie_lang_is_target_lang__should_redirect


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)

### Comments
1. `ignore_paths` should be checked before we do anything else. This is what every other backend does
   - use_cookie_lang
   - explicit default lang redirects
2. Remove language condition on ignore_paths. `ignore_paths` should be literal and really means do nothing if the request
matches it. This is consistent with other backends as well.
   - `/ignored_path?wovn=en` should be ignored.
   - I made it a major version bump due to the change in behavior