### PR TITLE
feature: [ST-3893] add x-default hreflang support

### DIFF
--- a/lib/wovnrb/api_translator.rb
+++ b/lib/wovnrb/api_translator.rb
@@ -114,6 +114,7 @@ module Wovnrb
         'lang_param_name' => lang_param_name,
         'translate_canonical_tag' => translate_canonical_tag,
         'insert_hreflangs' => insert_hreflangs,
+        'hreflang_x_default_lang' => @store.settings['hreflang_x_default_lang'], # should not use fallback, so html swapper can calculate the default lang from js_data
         'product' => 'WOVN.rb',
         'version' => VERSION,
         'page_status_code' => @response_status_code,

--- a/lib/wovnrb/services/html_converter.rb
+++ b/lib/wovnrb/services/html_converter.rb
@@ -152,7 +152,7 @@ module Wovnrb
         parent_node.add_child(insert_node.to_s)
       end
 
-      unless has_existing_x_default_hreflang?
+      unless existing_x_default_hreflang?
         insert_node = Nokogiri::XML::Node.new('link', @dom)
         insert_node['rel'] = 'alternate'
         insert_node['hreflang'] = 'x-default'
@@ -163,7 +163,7 @@ module Wovnrb
       end
     end
 
-    def has_existing_x_default_hreflang?
+    def existing_x_default_hreflang?
       @dom.xpath('//link').each do |node|
         return true if node['rel'].casecmp('alternate').zero? && node['hreflang'] && node['hreflang'].casecmp('x-default').zero?
       end

--- a/lib/wovnrb/services/html_converter.rb
+++ b/lib/wovnrb/services/html_converter.rb
@@ -152,14 +152,23 @@ module Wovnrb
         parent_node.add_child(insert_node.to_s)
       end
 
-      insert_node = Nokogiri::XML::Node.new('link', @dom)
-      insert_node['rel'] = 'alternate'
-      insert_node['hreflang'] = 'x-default'
-      insert_node['data-wovn'] = 'true'
-      x_default_lang_code = @store.hreflang_x_default_lang_or_default
-      insert_node['href'] = @headers.redirect_location(x_default_lang_code)
+      unless has_existing_x_default_hreflang?
+        insert_node = Nokogiri::XML::Node.new('link', @dom)
+        insert_node['rel'] = 'alternate'
+        insert_node['hreflang'] = 'x-default'
+        insert_node['data-wovn'] = 'true'
+        x_default_lang_code = @store.hreflang_x_default_lang_or_default
+        insert_node['href'] = @headers.redirect_location(x_default_lang_code)
+        parent_node.add_child(insert_node.to_s)
+      end
+    end
 
-      parent_node.add_child(insert_node.to_s)
+    def has_existing_x_default_hreflang?
+      @dom.xpath('//link').each do |node|
+        return true if node['rel'].casecmp('alternate').zero? && node['hreflang'] && node['hreflang'].casecmp('x-default').zero?
+      end
+
+      false
     end
 
     def translate_canonical_tag

--- a/lib/wovnrb/services/html_converter.rb
+++ b/lib/wovnrb/services/html_converter.rb
@@ -151,6 +151,14 @@ module Wovnrb
 
         parent_node.add_child(insert_node.to_s)
       end
+
+      insert_node = Nokogiri::XML::Node.new('link', @dom)
+      insert_node['rel'] = 'alternate'
+      insert_node['hreflang'] = 'x-default'
+      x_default_lang_code = @store.hreflang_x_default_lang_or_default
+      insert_node['href'] = @headers.redirect_location(x_default_lang_code)
+
+      parent_node.add_child(insert_node.to_s)
     end
 
     def translate_canonical_tag

--- a/lib/wovnrb/services/html_converter.rb
+++ b/lib/wovnrb/services/html_converter.rb
@@ -155,6 +155,7 @@ module Wovnrb
       insert_node = Nokogiri::XML::Node.new('link', @dom)
       insert_node['rel'] = 'alternate'
       insert_node['hreflang'] = 'x-default'
+      insert_node['data-wovn'] = 'true'
       x_default_lang_code = @store.hreflang_x_default_lang_or_default
       insert_node['href'] = @headers.redirect_location(x_default_lang_code)
 

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -65,7 +65,7 @@ module Wovnrb
     #
     # @return [Boolean] Returns true if the token is valid, and false if it is not
     def valid_token?(token)
-      !token.nil? && (token.length == 5 || token.length == 6)
+      !token.nil? && [5, 6].include?(token.length)
     end
 
     # Returns true or false based on whether the settings are valid or not, logs any invalid settings to ../error.log

--- a/lib/wovnrb/store.rb
+++ b/lib/wovnrb/store.rb
@@ -32,6 +32,7 @@ module Wovnrb
         'test_mode' => false,
         'test_url' => '',
         'cache_megabytes' => nil,
+        'hreflang_x_default_lang' => nil,
         'ttl_seconds' => nil,
         'use_proxy' => false, # use env['HTTP_X_FORWARDED_HOST'] instead of env['HTTP_HOST'] and env['SERVER_NAME'] when this setting is true.
         'custom_lang_aliases' => {},
@@ -141,6 +142,7 @@ module Wovnrb
       end
 
       @settings['default_lang'] = Lang.get_code(@settings['default_lang'])
+
       if !@settings.has_key?('supported_langs')
         @settings['supported_langs'] = [@settings['default_lang']]
       end
@@ -172,10 +174,16 @@ module Wovnrb
           @settings['api_timeout_seconds'] = 3.0
         end
       end
+
+      @settings['hreflang_x_default_lang'] = Lang.get_code(@settings['hreflang_x_default_lang'])
     end
 
     def custom_lang_aliases
       @settings['custom_lang_aliases'] || {}
+    end
+
+    def hreflang_x_default_lang_or_default
+      @settings['hreflang_x_default_lang'] || default_lang
     end
 
     def default_lang

--- a/lib/wovnrb/version.rb
+++ b/lib/wovnrb/version.rb
@@ -1,3 +1,3 @@
 module Wovnrb
-  VERSION = '3.12.0'.freeze
+  VERSION = '3.13.0'.freeze
 end

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -57,6 +57,7 @@ module Wovnrb
                          'lang_param_name' => 'lang',
                          'translate_canonical_tag' => true,
                          'insert_hreflangs' => true,
+                         'hreflang_x_default_lang' => nil,
                          'product' => 'WOVN.rb',
                          'version' => VERSION,
                          'page_status_code' => original_status_code,
@@ -209,11 +210,12 @@ module Wovnrb
         'lang_param_name' => 'lang',
         'translate_canonical_tag' => true,
         'insert_hreflangs' => true,
+        'hreflang_x_default_lang' => nil,
         'product' => 'WOVN.rb',
         'version' => VERSION,
         'page_status_code' => expected_status,
         'body' => original_html,
-        'custom_lang_aliases' => '{"ja":"Japanese"}'
+        'custom_lang_aliases' => '{"ja":"Japanese"}',
       }
 
       data.to_json

--- a/test/lib/api_translator_test.rb
+++ b/test/lib/api_translator_test.rb
@@ -215,7 +215,7 @@ module Wovnrb
         'version' => VERSION,
         'page_status_code' => expected_status,
         'body' => original_html,
-        'custom_lang_aliases' => '{"ja":"Japanese"}',
+        'custom_lang_aliases' => '{"ja":"Japanese"}'
       }
 
       data.to_json

--- a/test/lib/custom_domain/custom_domain_langs_test.rb
+++ b/test/lib/custom_domain/custom_domain_langs_test.rb
@@ -66,7 +66,7 @@ module Wovnrb
         'english.foo.com' => 'en'
       }
 
-      assert(hash_equals(expected, @custom_domain_langs.to_html_swapper_hash))
+      assert(hash_equals?(expected, @custom_domain_langs.to_html_swapper_hash))
     end
 
     private
@@ -75,7 +75,7 @@ module Wovnrb
       custom_domain_lang.lang
     end
 
-    def hash_equals(orig_hash, test_hash)
+    def hash_equals?(orig_hash, test_hash)
       (orig_hash <=> test_hash) == 0
     end
   end

--- a/test/lib/services/html_converter_test.rb
+++ b/test/lib/services/html_converter_test.rb
@@ -6,7 +6,7 @@ module Wovnrb
       converter = prepare_html_converter('<html><body><a class="test">hello</a></body></html>', supported_langs: %w[en vi])
       converted_html, = converter.build_api_compatible_html
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a class=\"test\">hello</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body><a class=\"test\">hello</a></body></html>"
       assert_equal(expected_html, converted_html)
     end
 
@@ -19,7 +19,7 @@ module Wovnrb
       converter = prepare_html_converter('<html><body><a class="test">hello</a></body></html>', settings)
       converted_html, = converter.build_api_compatible_html
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=lang&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?lang=vi\"></head><body><a class=\"test\">hello</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=lang&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?lang=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body><a class=\"test\">hello</a></body></html>"
       assert_equal(expected_html, converted_html)
     end
 
@@ -28,7 +28,7 @@ module Wovnrb
       converter = prepare_html_converter("<html><body><p>#{long_string}</p></body></html>", supported_langs: %w[en vi])
       converted_html, = converter.build_api_compatible_html
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><p>#{long_string}</p></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body><p>#{long_string}</p></body></html>"
       assert_equal(expected_html, converted_html)
     end
 
@@ -45,7 +45,7 @@ module Wovnrb
       converter = prepare_html_converter(html, ignore_class: ['ignore-me'])
       converted_html, = converter.build_api_compatible_html
 
-      expected_convert_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><p>Hello <span wovn-ignore=\"\"><!-- __wovn-backend-ignored-key-0 --></span></p><p></p><p>Hello <span data-wovn-ignore=\"\"><!-- __wovn-backend-ignored-key-1 --></span></p><p></p><div><span class=\"ignore-me\"><!-- __wovn-backend-ignored-key-2 --></span></div><span>Have a nice day!</span></body></html>"
+      expected_convert_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body><p>Hello <span wovn-ignore=\"\"><!-- __wovn-backend-ignored-key-0 --></span></p><p></p><p>Hello <span data-wovn-ignore=\"\"><!-- __wovn-backend-ignored-key-1 --></span></p><p></p><div><span class=\"ignore-me\"><!-- __wovn-backend-ignored-key-2 --></span></div><span>Have a nice day!</span></body></html>"
       assert_equal(expected_convert_html, converted_html)
     end
 
@@ -62,7 +62,7 @@ module Wovnrb
       converter = prepare_html_converter(html, ignore_class: [])
       converted_html, = converter.build_api_compatible_html
 
-      expected_convert_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><form action=\"/test\" method=\"POST\"><!-- __wovn-backend-ignored-key-0 --></form></body></html>"
+      expected_convert_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body><form action=\"/test\" method=\"POST\"><!-- __wovn-backend-ignored-key-0 --></form></body></html>"
       assert_equal(expected_convert_html, converted_html)
     end
 
@@ -81,7 +81,7 @@ module Wovnrb
 
       expected_convert_html = [
         '<html lang="en"><head>',
-        "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body>",
+        "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body>",
         '<input id="user-id" type="hidden" value="__wovn-backend-ignored-key-0">',
         '<input id="password" type="hidden" value="__wovn-backend-ignored-key-1">',
         '<input id="something" type="hidden" value="__wovn-backend-ignored-key-2">',
@@ -95,7 +95,7 @@ module Wovnrb
       converter = prepare_html_converter('<html><body><a>hello</a></body></html>', supported_langs: %w[en vi])
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body><a>hello</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -103,7 +103,7 @@ module Wovnrb
       converter = prepare_html_converter('<html><body><a>hello</a></body></html>', supported_langs: [])
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body><a>hello</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body><a>hello</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -111,7 +111,7 @@ module Wovnrb
       converter = prepare_html_converter('<html><head><title>TITLE</title></head><body><a>hello</a></body></html>', supported_langs: %w[en vi])
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><title>TITLE</title><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body><a>hello</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><title>TITLE</title><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body><a>hello</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -119,7 +119,7 @@ module Wovnrb
       converter = prepare_html_converter('<html>hello<a>world</a></html>', supported_langs: [])
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script></head><body>hello<a>world</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body>hello<a>world</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -135,7 +135,7 @@ module Wovnrb
       converter = HtmlConverter.new(dom, store, headers, url_lang_switcher)
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body>hello<a>world</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body>hello<a>world</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -152,7 +152,7 @@ module Wovnrb
       converter = HtmlConverter.new(dom, store, headers, url_lang_switcher)
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=vi&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"canonical\" href=\"http://my-site.com/vi/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/ja/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/vi/\"></head><body></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=vi&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"canonical\" href=\"http://my-site.com/vi/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/ja/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/vi/\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -169,7 +169,7 @@ module Wovnrb
       converter = HtmlConverter.new(dom, store, headers, url_lang_switcher)
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"canonical\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/ja/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/vi/\"></head><body></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"canonical\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/ja/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/vi/\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -186,7 +186,7 @@ module Wovnrb
       converter = HtmlConverter.new(dom, store, headers, url_lang_switcher)
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"canonical\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"canonical\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -204,7 +204,7 @@ module Wovnrb
       converter = HtmlConverter.new(dom, store, headers, url_lang_switcher)
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={&quot;en&quot;:&quot;english&quot;}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"canonical\" href=\"http://my-site.com/?wovn=english\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={&quot;en&quot;:&quot;english&quot;}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"canonical\" href=\"http://my-site.com/?wovn=english\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -221,7 +221,7 @@ module Wovnrb
       converter = HtmlConverter.new(dom, store, headers, url_lang_switcher)
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=vi&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"canonical\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/ja/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/vi/\"></head><body></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=vi&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"canonical\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/ja/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/vi/\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -237,7 +237,7 @@ module Wovnrb
       converter = HtmlConverter.new(dom, store, headers, url_lang_switcher)
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/ja/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/vi/\"></head><body>hello<a>world</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/ja/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/vi/\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body>hello<a>world</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -254,7 +254,7 @@ module Wovnrb
       converter = HtmlConverter.new(dom, store, headers, url_lang_switcher)
       translated_html = converter.build
 
-      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=custom_domain&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}&amp;customDomainLangs={&quot;my-site.com&quot;:&quot;en&quot;,&quot;french.com/fr&quot;:&quot;fr&quot;}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://french.com/fr/\"></head><body><a>hello</a></body></html>"
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=custom_domain&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}&amp;customDomainLangs={&quot;my-site.com&quot;:&quot;en&quot;,&quot;french.com/fr&quot;:&quot;fr&quot;}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://french.com/fr/\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body><a>hello</a></body></html>"
       assert_equal(expected_html, translated_html)
     end
 
@@ -279,7 +279,7 @@ module Wovnrb
       translated_html = converter.build
       dom = Helpers::NokogumboHelper.parse_html(translated_html)
       href_langs = dom.css('link[rel="alternate"]')
-      assert_equal(4, href_langs.length)
+      assert_equal(5, href_langs.length)
       expected_href_langs = {
         'en' =>
           {
@@ -296,12 +296,21 @@ module Wovnrb
         'vi' =>
           {
             'href' => 'http://my-site.com/?wovn=vi'
+          },
+        'x-default' =>
+          {
+            'href' => 'http://my-site.com/'
           }
       }
       href_langs.each do |node|
         assertions = expected_href_langs[node['hreflang']]
         assert_not_nil(assertions)
         assert_equal(assertions['href'], node['href'])
+        if node['hreflang'] == 'x-default'
+          assert_equal('true', node['data-wovn'])
+        else
+          assert_nil(node['data-wovn'])
+        end
       end
     end
 

--- a/test/lib/services/html_converter_test.rb
+++ b/test/lib/services/html_converter_test.rb
@@ -501,6 +501,35 @@ module Wovnrb
       assert_equal(expected_html, translated_html)
     end
 
+    test 'Transform HTML - no x-default hreflang - no config - generates using default lang' do
+      settings = default_store_settings
+      converter = prepare_html_converter('<html><head></head></html>', settings)
+      translated_html = converter.build
+
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/\"></head><body></body></html>"
+      assert_equal(expected_html, translated_html)
+    end
+
+    test 'Transform HTML - no x-default hreflang - has config - generates using specified lang' do
+      settings = default_store_settings
+      settings['hreflang_x_default_lang'] = 'fr'
+      converter = prepare_html_converter('<html><head></head></html>', settings)
+      translated_html = converter.build
+
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><link rel=\"alternate\" hreflang=\"x-default\" data-wovn=\"true\" href=\"http://my-site.com/?wovn=fr\"></head><body></body></html>"
+      assert_equal(expected_html, translated_html)
+    end
+
+    test 'Transform HTML - has x-default hreflang - does not modify' do
+      settings = default_store_settings
+      settings['hreflang_x_default_lang'] = 'fr'
+      converter = prepare_html_converter('<html><head><link rel="alternate" hreflang="X-Default" href="https://my-site.com/?from=customer"></head></html>', settings)
+      translated_html = converter.build
+
+      expected_html = "<html lang=\"en\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script src=\"https://j.wovn.io/1\" async=\"true\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases={}&amp;langParamName=wovn&amp;version=WOVN.rb_#{VERSION}\" data-wovnio-type=\"fallback_snippet\"></script><link rel=\"alternate\" hreflang=\"X-Default\" href=\"https://my-site.com/?from=customer\"><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/?wovn=fr\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"></head><body></body></html>"
+      assert_equal(expected_html, translated_html)
+    end
+
     private
 
     def prepare_html_converter(input_html, store_options = {})

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,7 @@ SimpleCov.start do
   track_files 'lib/**/*.rb'
 end
 
+require 'logger'
 require 'nokogiri'
 require 'rack'
 require 'minitest/autorun'


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
https://wovnio.atlassian.net/browse/ST-3895
https://github.com/WOVNio/wovnjava/pull/237
https://github.com/WOVNio/Wovn.cs/pull/96
https://github.com/WOVNio/wovnrb/pull/248
https://github.com/WOVNio/WOVN.php/pull/209
https://github.com/WOVNio/proxy/pull/193
https://github.com/WOVNio/wordpress_plugin/pull/130
https://github.com/WOVNio/html-swapper/pull/1179
https://github.com/WOVNio/equalizer/pull/73341

New setting: `hreflang_x_default_lang="fr"`

`<link rel="alternate" hreflang="X-Default" href="https://example.com/fr/">` will now be generated if the customer does not already have one on their page. The href will be based on the setting. If the setting doesn't exist, the default lang will be used.

html swapper will receive the raw setting, without calculating a fallback. Since html swapper can calculate it more accurately based on js_data.
### Comments


New tests:
- no customer x-default, generates using default lang if no setting
- no customer x-default, generates using setting language
- customer has x-default, does not modify